### PR TITLE
Fix exercise for predicates with generic Iterable annotation

### DIFF
--- a/predicate/spec/exercise.py
+++ b/predicate/spec/exercise.py
@@ -1,7 +1,7 @@
 from inspect import Parameter, Signature, signature
 from itertools import repeat
 from types import FunctionType
-from typing import Callable, Iterator, TypeVar
+from typing import Callable, Iterator, TypeVar, get_origin
 
 from more_itertools import take
 
@@ -46,8 +46,9 @@ def get_spec_from_class_annotation(f: Callable) -> Spec | None:
         if isinstance(f, Predicate):
             try:
                 spec["args"][key] = is_instance_p(f.klass)
-            except NotImplementedError:  # TODO this is ugly!
-                spec["args"][key] = always_true_p
+            except NotImplementedError:
+                origin = get_origin(annotation)
+                spec["args"][key] = is_instance_p(origin) if origin is not None else always_true_p
         elif type(annotation) is TypeVar:
             spec["args"][key] = always_true_p
         else:

--- a/test/test_is_empty_predicate.py
+++ b/test/test_is_empty_predicate.py
@@ -1,4 +1,3 @@
-import pytest
 from helpers import exercise_predicate
 
 from predicate import is_empty_p
@@ -20,6 +19,5 @@ def test_is_empty_explain():
     assert explain(is_empty_p, {1, 2, 3}) == expected
 
 
-@pytest.mark.skip("TODO")
 def test_is_empty_exercise():
     exercise_predicate(is_empty_p)

--- a/test/test_is_not_empty_predicate.py
+++ b/test/test_is_not_empty_predicate.py
@@ -1,4 +1,3 @@
-import pytest
 from helpers import exercise_predicate
 
 from predicate import is_not_empty_p
@@ -20,6 +19,5 @@ def test_is_not_empty_explain():
     assert explain(is_not_empty_p, []) == expected
 
 
-@pytest.mark.skip("TODO")
 def test_is_not_empty_exercise():
     exercise_predicate(is_not_empty_p)


### PR DESCRIPTION
## Summary

- When `f.klass` raises `NotImplementedError`, use `get_origin(annotation)` to extract the concrete type from a generic annotation (e.g. `Iterable[T]` → `Iterable`) instead of falling back to `always_true_p`
- Removes the TODO comment about this being ugly
- Enables `test_is_empty_exercise` and `test_is_not_empty_exercise` by removing their `@pytest.mark.skip` markers
- Removes now-unused `pytest` imports from both test files

## Root cause

`is_empty_p` and `is_not_empty_p` are `HasLengthPredicate` instances. `HasLengthPredicate` doesn't implement `get_klass()`, so the fallback to `always_true_p` caused `exercise()` to generate arbitrary values including bools. When `HasLengthPredicate.__call__` received a bool, it called `ilen(True)` which raises `TypeError: 'bool' object is not iterable`.

## Test plan

- [x] `test_is_empty_exercise` passes
- [x] `test_is_not_empty_exercise` passes
- [x] Full suite: 1343 passed, 8 skipped (2 fewer skipped than before)
- [x] `ruff check .` passes
- [x] `black . --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)