### PR TITLE
Add tests for has_path_predicate to reach 100% coverage

### DIFF
--- a/predicate/has_path_predicate.py
+++ b/predicate/has_path_predicate.py
@@ -33,7 +33,7 @@ class HasPathPredicate[T](Predicate[T]):
                     if not keys:
                         return {"reason": f"No key matching {p!r} found at path position {i}"}
                     current = current[keys[0]]
-                return {"reason": f"Dictionary {x} didn't match path"}
+                return {"reason": f"Dictionary {x} didn't match path"}  # pragma: no cover
             case _:
                 return {"reason": f"Value {x} is not a dict"}
 

--- a/test/test_has_path_predicate.py
+++ b/test/test_has_path_predicate.py
@@ -74,3 +74,19 @@ def test_has_path_predicate_no_match_explain():
 
     expected = {"reason": "No key matching eq_p('x') found at path position 0", "result": False}
     assert explain(predicate, {"y": 13}) == expected
+
+
+def test_has_path_predicate_repr():
+    has_x = eq_p("x")
+    predicate = has_path_p(has_x)
+
+    assert repr(predicate) == "has_path_p(eq_p('x'))"
+
+
+def test_has_path_predicate_non_dict_intermediate_explain():
+    has_x = eq_p("x")
+    has_y = eq_p("y")
+    predicate = has_path_p(has_x, has_y)
+
+    expected = {"reason": "Expected a dict at path position 1, got int", "result": False}
+    assert explain(predicate, {"x": 13}) == expected


### PR DESCRIPTION
Cover __repr__, explain with non-dict intermediate value, and mark the unreachable defensive fallback line with pragma: no cover.

🤖 Created with help from [Claude Code](https://claude.com/claude-code)