### PR TITLE
Fix generate_true for any_p(is_tuple_of_p(..., is_truthy_p)) predicate

### DIFF
--- a/docs/tutorial/tutorial_2.rst
+++ b/docs/tutorial/tutorial_2.rst
@@ -40,3 +40,12 @@ Now you are ready to check your new predicate against the requirements, for exam
     predicate([(uuid4(), "foo", 1)])  # True: 1 is a truthy value
     predicate([(uuid4(), "meh", 1)])  # False: missing "foo" or "bar"
     predicate([("not_a_uuid", "foo", 1)])  # False: missing uuid
+
+You can also generate example values that satisfy the predicate, using ``generate_true``:
+
+.. code-block:: python
+
+    from predicate import generate_true
+    from more_itertools import take
+
+    values = take(3, generate_true(predicate))

--- a/predicate/generator/generate_false.py
+++ b/predicate/generator/generate_false.py
@@ -347,7 +347,7 @@ def generate_not_none(_predicate: IsNotNonePredicate) -> Iterator:
 
 @generate_false.register
 def generate_truthy(_predicate: IsTruthyPredicate) -> Iterator:
-    yield from (False, 0, (), "", {})
+    yield from cycle((False, 0, (), "", {}))
 
 
 @generate_false.register

--- a/predicate/generator/generate_true.py
+++ b/predicate/generator/generate_true.py
@@ -3,7 +3,7 @@ import sys
 from collections.abc import Callable, Container, Iterable, Iterator
 from datetime import datetime, timedelta
 from functools import singledispatch
-from itertools import repeat
+from itertools import cycle, repeat
 from types import UnionType
 from typing import Any, Final, Hashable, get_args
 from uuid import UUID
@@ -428,12 +428,12 @@ def generate_regex(predicate: RegexPredicate) -> Iterator:
 
 @generate_true.register
 def generate_falsy(_predicate: IsFalsyPredicate) -> Iterator:
-    yield from (False, 0, (), "", {})
+    yield from cycle((False, 0, (), "", {}))
 
 
 @generate_true.register
 def generate_truthy(_predicate: IsTruthyPredicate) -> Iterator:
-    yield from (True, 1, "true", {1}, 3.14)
+    yield from cycle((True, 1, "true", frozenset({1}), 3.14))
 
 
 @generate_true.register

--- a/test/generator/generate_true/test_generate_true.py
+++ b/test/generator/generate_true/test_generate_true.py
@@ -25,6 +25,7 @@ from predicate import (
     gt_p,
     has_key_p,
     has_length_p,
+    in_p,
     is_bool_p,
     is_callable_p,
     is_complex_p,
@@ -82,6 +83,7 @@ def foo(self) -> bool:
     "predicate",
     [
         any_p(is_uuid_p),
+        any_p(is_tuple_of_p(is_uuid_p, in_p({"foo", "bar"}), is_truthy_p)),
         eq_false_p,
         eq_true_p,
         has_key_p("foo"),
@@ -346,6 +348,7 @@ def test_predicate_of(klass):
         (is_int_p,),
         (is_str_p,),
         (is_int_p, is_int_p),
+        (is_uuid_p, in_p({"foo", "bar"}), is_truthy_p),
     ],
 )
 def test_tuple_of(tuple_types_p):


### PR DESCRIPTION
generate_truthy and generate_falsy were finite generators (5 values), causing generate_false(TupleOfPredicate) to exhaust them when reusing the same generator objects in a while loop. This raised ValueError when generating larger collections via any_p.

Fix by cycling all finite truthy/falsy generators so they are infinite. Also replace {1} with frozenset({1}) to keep generated tuples hashable.

Adds tests for the tutorial 2 predicate and updates the tutorial to show generate_true usage.

🤖 Created with help from [Claude Code](https://claude.com/claude-code)