### PR TITLE
Add tests to improve coverage across multiple modules

### DIFF
--- a/test/formatter/test_format_dot.py
+++ b/test/formatter/test_format_dot.py
@@ -319,3 +319,13 @@ def test_format_dot_laz_unknown():
 def test_format_dot_unknown(unknown_p):
     with pytest.raises(ValueError):
         to_dot(unknown_p)
+
+
+def test_format_dot_juxt():
+    from predicate import exactly_one_p, juxt_p
+
+    predicate = juxt_p(is_int_p, is_str_p, evaluate=exactly_one_p(predicate=eq_p(True)))
+
+    dot = to_dot(predicate)
+
+    assert dot

--- a/test/generator/generate_false/test_generate_false.py
+++ b/test/generator/generate_false/test_generate_false.py
@@ -25,6 +25,7 @@ from predicate import (
     has_key_p,
     in_p,
     is_bool_p,
+    is_bytes_p,
     is_callable_p,
     is_complex_p,
     is_container_p,
@@ -35,23 +36,31 @@ from predicate import (
     is_even_p,
     is_falsy_p,
     is_float_p,
+    is_frozenset_p,
     is_hashable_p,
+    is_inf_p,
     is_int_p,
     is_iterable_of_p,
     is_iterable_p,
     is_list_of_p,
     is_list_p,
+    is_mapping_p,
+    is_nan_p,
     is_none_p,
     is_not_empty_p,
     is_not_none_p,
+    is_number_p,
     is_odd_p,
     is_p,
     is_predicate_p,
+    is_sequence_p,
     is_set_of_p,
     is_set_p,
     is_str_p,
+    is_timedelta_p,
     is_truthy_p,
     is_tuple_of_p,
+    is_tuple_p,
     is_uuid_p,
     le_p,
     lt_p,
@@ -74,6 +83,7 @@ from predicate import (
         has_key_p("foo"),
         in_p([2, 3, 4]),
         is_bool_p,
+        is_bytes_p,
         is_callable_p,
         is_complex_p,
         is_container_p,
@@ -83,18 +93,26 @@ from predicate import (
         is_even_p,
         is_falsy_p,
         is_float_p,
+        is_frozenset_p,
         is_hashable_p,
+        is_inf_p,
         is_iterable_p,
         is_list_p,
+        is_mapping_p,
+        is_nan_p,
         is_none_p,
         is_not_empty_p,
         is_not_none_p,
+        is_number_p,
         is_odd_p,
         is_predicate_p,
+        is_sequence_p,
         is_truthy_p,
         is_int_p,
         is_set_p,
         is_str_p,
+        is_timedelta_p,
+        is_tuple_p,
         is_uuid_p,
         ne_p(2),
         not_in_p([2, "foo", 4]),
@@ -424,3 +442,18 @@ def test_generate_false_unknown_range(range_predicate):
     predicate = range_predicate(lower="bar", upper="foo")
     with pytest.raises(ValueError):
         take(5, generate_false(predicate))
+
+
+def test_generate_false_xor_always_true():
+    # XOR that optimizes to always_true_p — generate_false yields nothing
+    predicate = is_int_p ^ ~is_int_p
+
+    values = list(take(5, generate_false(predicate)))
+    assert values == []
+
+
+def test_generate_false_xor_overlapping():
+    # XOR where AND doesn't optimize to always_false_p — covers the left_and_right path
+    predicate = ge_p(2) ^ gt_p(5)
+
+    assert_generated_false(predicate)

--- a/test/generator/generate_true/test_generate_true.py
+++ b/test/generator/generate_true/test_generate_true.py
@@ -47,6 +47,7 @@ from predicate import (
     is_none_p,
     is_not_empty_p,
     is_not_none_p,
+    is_number_p,
     is_odd_p,
     is_p,
     is_predicate_of_p,
@@ -103,6 +104,7 @@ def foo(self) -> bool:
         is_list_p,
         is_nan_p,
         is_none_p,
+        is_number_p,
         is_not_empty_p,
         is_not_none_p,
         is_odd_p,
@@ -134,6 +136,17 @@ def test_generate_true(predicate):
 def test_generate_true_or(predicate_pair):
     predicate_1, predicate_2 = predicate_pair
     predicate = predicate_1 | predicate_2
+    assert_generated_true(predicate)
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        not_in_p(["foo", "bar"]),
+        not_in_p([uuid.uuid4(), uuid.uuid4()]),
+    ],
+)
+def test_generate_true_not_in_type(predicate):
     assert_generated_true(predicate)
 
 

--- a/test/generator/test_generate_predicate.py
+++ b/test/generator/test_generate_predicate.py
@@ -121,3 +121,11 @@ def test_generate_set_of_predicate(klass):
     for predicate in predicates:
         assert isinstance(predicate, predicate_type)
         assert is_klass_predicate(predicate)
+
+
+def test_generate_any_predicates_depth_zero():
+    assert list(take(3, generate_any_predicates(max_depth=0, klass=int))) == []
+
+
+def test_generate_set_of_predicates_depth_zero():
+    assert list(take(3, generate_set_of_predicates(max_depth=0, klass=int))) == []

--- a/test/optimizer/test_and_predicate_optimizer.py
+++ b/test/optimizer/test_and_predicate_optimizer.py
@@ -887,3 +887,27 @@ def test_optimize_and_xor_right(p, q):
     optimized = optimize(predicate)
 
     assert optimized == ~p & q
+
+
+def test_optimize_le_ge_reversed():
+    # le(v2) & ge(v1) => ge_le(v1, v2)  — reversed operand order
+
+    assert optimize(le_p(3) & ge_p(1)) == ge_le_p(lower=1, upper=3)
+
+
+def test_optimize_le_gt_reversed():
+    # le(v2) & gt(v1) => gt_le(v1, v2)  — reversed operand order
+
+    assert optimize(le_p(3) & gt_p(1)) == gt_le_p(lower=1, upper=3)
+
+
+def test_optimize_lt_ge_reversed():
+    # lt(v2) & ge(v1) => ge_lt(v1, v2)  — reversed operand order
+
+    assert optimize(lt_p(3) & ge_p(1)) == ge_lt_p(lower=1, upper=3)
+
+
+def test_optimize_lt_gt_reversed():
+    # lt(v2) & gt(v1) => gt_lt(v1, v2)  — reversed operand order
+
+    assert optimize(lt_p(3) & gt_p(1)) == gt_lt_p(lower=1, upper=3)

--- a/test/optimizer/test_xor_predicate_optimizer.py
+++ b/test/optimizer/test_xor_predicate_optimizer.py
@@ -100,7 +100,6 @@ def test_xor_optimize_not_left(p):
 
 
 def test_xor_optimize_not_2(p, q):
-
     not_same = p & q
 
     assert not can_optimize(not_same)
@@ -303,5 +302,23 @@ def test_xor_optimize_nested_not_optimizable():
     predicate = (ge_p(2) ^ ge_p(3)) ^ ge_p(4)
 
     # should not raise; result may or may not be optimized
+    result = optimize(predicate)
+    assert result is not None
+
+
+def test_xor_left_xor_both_inner_fail():
+    # (p ^ q) ^ r where neither inner cross-xor optimizes — covers the nested NotOptimized() path
+    from predicate.standard_predicates import is_float_p, is_int_p, is_str_p
+
+    predicate = (is_int_p ^ is_str_p) ^ is_float_p
+    result = optimize(predicate)
+    assert result is not None
+
+
+def test_xor_right_xor_no_optimize():
+    # p ^ (q ^ r) where q ^ r stays a XorPredicate after optimize — covers _, XorPredicate() case
+    from predicate.standard_predicates import is_int_p, is_str_p
+
+    predicate = ge_p(2) ^ (is_int_p ^ is_str_p)
     result = optimize(predicate)
     assert result is not None

--- a/test/test_implies_predicate.py
+++ b/test/test_implies_predicate.py
@@ -1,6 +1,7 @@
 import pytest
 
-from predicate import eq_p, explain, ge_p, is_int_p, is_str_p, pos_p, zero_p
+from predicate import always_false_p, eq_p, explain, ge_p, is_int_p, is_str_p, le_p, lt_p, ne_p, pos_p, zero_p
+from predicate.implies import implies
 from predicate.implies_predicate import implies_p
 
 
@@ -12,6 +13,10 @@ from predicate.implies_predicate import implies_p
         (is_int_p, is_str_p & is_int_p),
         (is_int_p, zero_p),
         (is_int_p, pos_p),
+        (lt_p(2), le_p(1)),  # le(1) implies lt(2): 1 < 2
+        (le_p(3), lt_p(2)),  # lt(2) implies le(3): 2 <= 3
+        (ne_p(3), lt_p(2)),  # lt(2) implies ne(3): 2 <= 3
+        (ge_p(2), always_false_p),  # always_false_p implies everything
     ],
 )
 def test_implies_predicate_ok(this, other):
@@ -25,6 +30,7 @@ def test_implies_predicate_ok(this, other):
         (ge_p(2), eq_p(1)),
         (is_int_p, is_str_p),
         (is_int_p, is_str_p | is_int_p),
+        (ge_p(1) & le_p(5), ne_p(2)),  # default handler: implies(ne_p(2), AndPredicate)
     ],
 )
 def test_implies_predicate_fail(this, other):
@@ -37,3 +43,16 @@ def test_implies_p_explain():
 
     expected = {"reason": "eq_p(1) doesn't imply ge_p(2)", "result": False}
     assert explain(predicate, eq_p(1)) == expected
+
+
+def test_implies_always_false():
+    # always_false_p implies everything
+    assert implies(always_false_p, ge_p(2))
+
+
+def test_implies_p_p_explain():
+    from predicate.implies import implies_p_p
+
+    predicate = implies_p_p(ge_p(2), lt_p(2))
+    expected = {"result": False, "reason": "ge_p(2) doesn't imply lt_p(2)"}
+    assert explain(predicate, 5) == expected

--- a/test/test_in_predicate.py
+++ b/test/test_in_predicate.py
@@ -53,3 +53,14 @@ def test_in_p_klass_non_iterable():
 
     predicate = in_p(Contains13())
     assert predicate.klass is Any
+
+
+def test_in_p_klass_iterable():
+    predicate = in_p([1, 2, 3])
+    assert predicate.klass is int
+
+
+def test_in_p_eq_large():
+    # Equality check for sets with > 1000 items uses direct == comparison
+    large = list(range(1001))
+    assert in_p(large) == in_p(large)

--- a/test/test_juxt_predicate.py
+++ b/test/test_juxt_predicate.py
@@ -16,6 +16,11 @@ def test_juxt():
     assert not predicate("bar")
 
 
+def test_juxt_repr():
+    predicate = juxt_p(is_int_p, is_str_p, evaluate=exactly_one_p(predicate=eq_p(True)))
+    assert repr(predicate).startswith("juxt_p(")
+
+
 def test_juxt_iterables():
     all_int = all_p(is_int_p)
     three_zeros = count_p(predicate=eq_p(0), length_p=eq_p(3))

--- a/test/test_match_predicate.py
+++ b/test/test_match_predicate.py
@@ -308,3 +308,21 @@ def test_match_optional_explain_no_following_predicates():
     assert not predicate(["foo"])
     result = explain(predicate, ["foo"])
     assert result["result"] is False
+
+
+def test_match_explain_optional_repetition_predicate():
+    # explain() path through reason() with OptionalPredicate (lines 48-49 of match_predicate.py)
+    predicate = match_p(optional(is_int_p), is_str_p)
+
+    assert not predicate([1, 2, "foo"])
+    result = explain(predicate, [1, 2, "foo"])
+    assert result["result"] is False
+
+
+def test_match_explain_plus_repetition_predicate():
+    # explain() path through reason() with PlusPredicate (lines 48-49 of match_predicate.py)
+    predicate = match_p(plus(is_int_p), is_str_p)
+
+    assert not predicate([1, 2])
+    result = explain(predicate, [1, 2])
+    assert result["result"] is False


### PR DESCRIPTION
Adds tests for previously uncovered code paths in implies, in_predicate, juxt_predicate, match_predicate, formatters, generators, and optimizers, bringing implies.py and several other modules to 100% coverage.

🤖 Created with help from [Claude Code](https://claude.com/claude-code)