### PR TITLE
Fix instrument_function building unbounded wrapper chain

### DIFF
--- a/predicate/spec/instrument.py
+++ b/predicate/spec/instrument.py
@@ -1,5 +1,6 @@
 import sys
 from functools import wraps
+from inspect import unwrap
 from typing import Callable
 
 from predicate import explain
@@ -7,6 +8,7 @@ from predicate.spec.spec import Spec
 
 
 def instrument_function(func: Callable, spec: Spec) -> Callable:
+    func = unwrap(func)
     func_name = func.__name__
 
     @wraps(func)


### PR DESCRIPTION
## Summary

- Fixes a flaky test failure in `test_instrument.py` that appeared when the full suite ran but not in isolation
- Root cause: `instrument_function` uses `@wraps(func)` and then patches the module with `setattr(module, func_name, wrapped)`. The `autouse=True` fixture called it for every test, each time importing the already-wrapped version from the module, causing the `__wrapped__` chain to grow by 1 per test. After ~1000 tests, `inspect.unwrap` (called internally by `inspect.signature`) exceeded `sys.getrecursionlimit()` and raised `ValueError: wrapper`.
- Fix: call `unwrap(func)` at the start of `instrument_function` so it always wraps the original function — repeated calls are now idempotent.

## Test plan

- [x] `test/spec/test_instrument.py` — all 5 tests pass
- [x] Full suite of 1636 tests passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)