### PR TITLE
Fix type annotations in IsInstancePredicate to eliminate type: ignore

### DIFF
--- a/predicate/formatter/format_dot.py
+++ b/predicate/formatter/format_dot.py
@@ -149,7 +149,7 @@ def render(dot: Digraph, predicate: Predicate, node_nr: count):
             case Implies(left, right):
                 return add_node_left_right("implies", label="=>", left=left, right=right)
             case IsInstancePredicate(klass):
-                name = klass[0].__name__  # type: ignore
+                name = klass[0].__name__
                 return add_node("instance", label=f"is_{name}_p")
             case IsNonePredicate():
                 return add_node("none", label="x = None")

--- a/predicate/generator/generate_true.py
+++ b/predicate/generator/generate_true.py
@@ -443,7 +443,7 @@ def generate_predicate_of(predicate: IsPredicateOfPredicate, **kwargs) -> Iterat
 
 @generate_true.register
 def generate_is_instance_p(predicate: IsInstancePredicate, **kwargs) -> Iterator:
-    klass = predicate.instance_klass[0]  # type: ignore
+    klass = predicate.instance_klass[0]
 
     type_registry: dict[Any, Callable[[], Iterator]] = {
         Callable: random_callables,

--- a/predicate/implies.py
+++ b/predicate/implies.py
@@ -68,7 +68,7 @@ def _(predicate: GePredicate, other: Predicate) -> bool:
 def _(predicate: GtPredicate, other: Predicate) -> bool:
     match other:
         case IsInstancePredicate(instance_klass):
-            return predicate.klass == instance_klass[0]  # type: ignore
+            return predicate.klass == instance_klass[0]
         case GePredicate(v):
             return predicate.v >= v
         case GtPredicate(v):
@@ -107,7 +107,7 @@ def _(predicate: LtPredicate, other: Predicate) -> bool:
 def _(predicate: EqPredicate, other: Predicate) -> bool:
     match other:
         case IsInstancePredicate(instance_klass):
-            return predicate.klass == instance_klass[0]  # type: ignore
+            return predicate.klass == instance_klass[0]
         case EqPredicate(v):
             return predicate.v == v
         case NePredicate(v):

--- a/predicate/is_instance_predicate.py
+++ b/predicate/is_instance_predicate.py
@@ -13,18 +13,18 @@ from predicate.predicate import Predicate
 class IsInstancePredicate[T](Predicate[T]):
     """A predicate class that models the 'isinstance' predicate."""
 
-    instance_klass: tuple
+    instance_klass: tuple[type, ...]
 
     def __call__(self, x: object) -> TypeGuard[T]:
         # This is different from standard Python behavior: a False/True value is not an int!
-        if isinstance(x, bool) and self.instance_klass[0] is int:  # type: ignore
+        if isinstance(x, bool) and self.instance_klass[0] is int:
             return False
-        if (origin := get_origin(self.instance_klass[0])) is not None:  # type: ignore
-            return isinstance(x, origin)  # type: ignore
+        if (origin := get_origin(self.instance_klass[0])) is not None:
+            return isinstance(x, origin)  # type: ignore[arg-type]
         return isinstance(x, self.instance_klass)
 
     def __repr__(self) -> str:
-        name = self.instance_klass[0].__name__  # type: ignore
+        name = self.instance_klass[0].__name__
         return f"is_{name}_p"
 
     @override


### PR DESCRIPTION
Change `instance_klass: tuple` to `tuple[type, ...]` so mypy can verify index access and attribute lookup on its elements without suppression. Removes 6 type: ignore comments across 4 files.

🤖 Created with help from [Claude Code](https://claude.com/claude-code)