### PR TITLE
Fix generate_or hanging due to generator truthiness bug

### DIFF
--- a/predicate/generator/generate_false.py
+++ b/predicate/generator/generate_false.py
@@ -376,17 +376,25 @@ def generate_is_lambda_p(predicate: IsLambdaPredicate) -> Iterator:
 @generate_false.register
 def generate_or(predicate: OrPredicate) -> Iterator:
     attempts = 100
+    _sentinel = object()
 
-    try_left = (item for item in take(attempts, generate_false(predicate.left)) if not predicate.right(item))
-    try_right = (item for item in take(attempts, generate_false(predicate.right)) if not predicate.left(item))
+    first_left = next(
+        (item for item in take(attempts, generate_false(predicate.left)) if not predicate.right(item)), _sentinel
+    )
+    first_right = next(
+        (item for item in take(attempts, generate_false(predicate.right)) if not predicate.left(item)), _sentinel
+    )
 
-    range_1 = (item for item in generate_false(predicate.left) if not predicate.right(item)) if try_left else ()
-    range_2 = (item for item in generate_false(predicate.right) if not predicate.left(item)) if try_right else ()
+    iterables = []
+    if first_left is not _sentinel:
+        iterables.append(item for item in generate_false(predicate.left) if not predicate.right(item))
+    if first_right is not _sentinel:
+        iterables.append(item for item in generate_false(predicate.right) if not predicate.left(item))
 
-    if range_1 or range_2:
-        yield from random_first_from_iterables(range_1, range_2)
+    if not iterables:
+        raise ValueError(f"Couldn't generate values that satisfy {predicate}")
 
-    raise ValueError(f"Couldn't generate values that statisfy {predicate}")
+    yield from random_first_from_iterables(*iterables)
 
 
 @generate_false.register


### PR DESCRIPTION
Generator expression objects are always truthy in Python, so the `if try_left else ()` guard never triggered the fallback to `()`. This caused `random_first_from_iterables` to always be called with infinite generators, which could hang indefinitely on Linux CI when the filter rarely/never passed.

Fix by actually consuming the sample generators with `next(..., sentinel)` to determine which sides are viable before building the iterable list. Also fixes typo: statisfy → satisfy.

🤖 Created with help from [Claude Code](https://claude.com/claude-code)