### PR TITLE
Add raises_p predicate (closes #180)

### DIFF
--- a/docs/standard_predicates.rst
+++ b/docs/standard_predicates.rst
@@ -878,6 +878,35 @@ This predicate tests for non equality
     assert ne_2(3)
 
 
+raises_p
+--------
+
+This predicate tests if a callable (thunk) raises an exception when called.
+Returns True if calling the thunk raises any exception, False otherwise.
+
+.. code-block:: python
+
+    from predicate import raises_p
+
+    assert raises_p(lambda: 1 / 0)
+    assert raises_p(lambda: int("x"))
+    assert not raises_p(lambda: 1)
+
+raises_exception_p
+------------------
+
+This predicate tests if a callable raises a specific exception type when called.
+Returns True only if the exact exception type (or a subclass of it) is raised.
+
+.. code-block:: python
+
+    from predicate import raises_exception_p
+
+    assert raises_exception_p(ValueError)(lambda: int("x"))
+    assert raises_exception_p(Exception)(lambda: 1 / 0)    # ZeroDivisionError is a subclass of Exception
+    assert not raises_exception_p(ValueError)(lambda: 1 / 0)  # wrong exception type
+    assert not raises_exception_p(ValueError)(lambda: 1)       # no exception raised
+
 tee_p
 -----
 

--- a/docs/standard_predicates.rst
+++ b/docs/standard_predicates.rst
@@ -883,6 +883,7 @@ raises_p
 
 This predicate tests if a callable (thunk) raises an exception when called.
 Returns True if calling the thunk raises any exception, False otherwise.
+Both synchronous and async callables are supported.
 
 .. code-block:: python
 
@@ -892,11 +893,25 @@ Returns True if calling the thunk raises any exception, False otherwise.
     assert raises_p(lambda: int("x"))
     assert not raises_p(lambda: 1)
 
+Async functions are also supported:
+
+.. code-block:: python
+
+    async def fetch():
+        raise ConnectionError("unreachable")
+
+    async def ok():
+        return 42
+
+    assert raises_p(fetch)
+    assert not raises_p(ok)
+
 raises_exception_p
 ------------------
 
 This predicate tests if a callable raises a specific exception type when called.
 Returns True only if the exact exception type (or a subclass of it) is raised.
+Both synchronous and async callables are supported.
 
 .. code-block:: python
 
@@ -906,6 +921,11 @@ Returns True only if the exact exception type (or a subclass of it) is raised.
     assert raises_exception_p(Exception)(lambda: 1 / 0)    # ZeroDivisionError is a subclass of Exception
     assert not raises_exception_p(ValueError)(lambda: 1 / 0)  # wrong exception type
     assert not raises_exception_p(ValueError)(lambda: 1)       # no exception raised
+
+    async def async_value_error():
+        raise ValueError("bad input")
+
+    assert raises_exception_p(ValueError)(async_value_error)
 
 tee_p
 -----

--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -69,6 +69,7 @@ from predicate.optimizer.predicate_optimizer import can_optimize, optimize
 from predicate.optional_predicate import optional
 from predicate.plus_predicate import plus
 from predicate.predicate import and_p, or_p, xor_p
+from predicate.raises_predicate import RaisesPredicate, raises_exception_p, raises_p
 from predicate.range_predicate import ge_le_p, ge_lt_p, gt_le_p, gt_lt_p
 from predicate.recur_predicate import recur_p
 from predicate.reduce_predicate import reduce_p
@@ -225,6 +226,9 @@ __all__ = [
     "pos_p",
     "recur_p",
     "reduce_p",
+    "RaisesPredicate",
+    "raises_exception_p",
+    "raises_p",
     "regex_p",
     "repeat",
     "root_p",

--- a/predicate/generator/generate_false.py
+++ b/predicate/generator/generate_false.py
@@ -66,6 +66,7 @@ from predicate.optimizer.predicate_optimizer import optimize
 from predicate.optional_predicate import OptionalPredicate
 from predicate.plus_predicate import PlusPredicate
 from predicate.predicate import AndPredicate, NotPredicate, OrPredicate, Predicate, XorPredicate
+from predicate.raises_predicate import RaisesPredicate
 from predicate.range_predicate import GeLePredicate, GeLtPredicate, GtLePredicate, GtLtPredicate, ge_le_p
 from predicate.regex_predicate import RegexPredicate
 from predicate.repeat_predicate import RepeatPredicate
@@ -623,3 +624,8 @@ def generate_regex(predicate: RegexPredicate) -> Iterator:
 @generate_false.register
 def generate_is_callable(predicate: IsCallablePredicate) -> Iterator:
     yield from (item for item in random_anys() if not predicate(item))
+
+
+@generate_false.register
+def generate_raises(predicate: RaisesPredicate) -> Iterator:
+    yield from repeat(lambda: None)

--- a/predicate/generator/generate_true.py
+++ b/predicate/generator/generate_true.py
@@ -92,6 +92,7 @@ from predicate.predicate import (
     XorPredicate,
 )
 from predicate.property_predicate import PropertyPredicate
+from predicate.raises_predicate import RaisesPredicate
 from predicate.range_predicate import GeLePredicate, GeLtPredicate, GtLePredicate, GtLtPredicate, ge_le_p
 from predicate.regex_predicate import RegexPredicate
 from predicate.repeat_predicate import RepeatPredicate
@@ -687,3 +688,10 @@ def generate_is(is_predicate: IsPredicate) -> Iterator:
 @generate_true.register
 def generate_juxt_p(predicate: JuxtPredicate) -> Iterator:
     yield from (item for item in random_anys() if predicate(item))
+
+
+@generate_true.register
+def generate_raises(predicate: RaisesPredicate) -> Iterator:
+    exc_type = predicate.exception_type
+    while True:
+        yield lambda: (_ for _ in ()).throw(exc_type())

--- a/predicate/raises_predicate.py
+++ b/predicate/raises_predicate.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, field
+from typing import Any, Final, override
+
+from predicate.predicate import Predicate
+
+
+@dataclass
+class RaisesPredicate[T](Predicate[T]):
+    """A predicate that returns True if a callable raises an exception."""
+
+    exception_type: type[Exception] = field(default=Exception)
+
+    def __call__(self, x: Any) -> bool:
+        try:
+            x()
+            return False
+        except self.exception_type:
+            return True
+        except Exception:
+            return False  # raised a different exception type
+
+    def __repr__(self) -> str:
+        if self.exception_type is Exception:
+            return "raises_p"
+        return f"raises_exception_p({self.exception_type.__name__})"
+
+    @override
+    def explain_failure(self, x: Any) -> dict:
+        try:
+            x()
+            return {"reason": "callable did not raise an exception"}
+        except self.exception_type:
+            return {}  # shouldn't reach here
+        except Exception as e:
+            return {"reason": f"raised {type(e).__name__}, expected {self.exception_type.__name__}"}
+
+
+raises_p: Final[RaisesPredicate] = RaisesPredicate()
+"""Return True if the callable raises any exception."""
+
+
+def raises_exception_p(exception_type: type[Exception]) -> RaisesPredicate:
+    """Return True if the callable raises the specified exception type."""
+    return RaisesPredicate(exception_type=exception_type)

--- a/predicate/raises_predicate.py
+++ b/predicate/raises_predicate.py
@@ -1,7 +1,16 @@
+import asyncio
+from asyncio import iscoroutinefunction
 from dataclasses import dataclass, field
 from typing import Any, Final, override
 
 from predicate.predicate import Predicate
+
+
+def _call(x: Any) -> None:
+    if iscoroutinefunction(x):
+        asyncio.run(x())
+    else:
+        x()
 
 
 @dataclass
@@ -12,7 +21,7 @@ class RaisesPredicate[T](Predicate[T]):
 
     def __call__(self, x: Any) -> bool:
         try:
-            x()
+            _call(x)
             return False
         except self.exception_type:
             return True
@@ -27,7 +36,7 @@ class RaisesPredicate[T](Predicate[T]):
     @override
     def explain_failure(self, x: Any) -> dict:
         try:
-            x()
+            _call(x)
             return {"reason": "callable did not raise an exception"}
         except self.exception_type:
             return {}  # shouldn't reach here

--- a/test/generator/generate_false/test_generate_raises.py
+++ b/test/generator/generate_false/test_generate_raises.py
@@ -1,0 +1,10 @@
+from generator.generate_false.helpers import assert_generated_false
+from predicate import raises_exception_p, raises_p
+
+
+def test_generate_raises_p():
+    assert_generated_false(raises_p)
+
+
+def test_generate_raises_exception_p():
+    assert_generated_false(raises_exception_p(ValueError))

--- a/test/generator/generate_true/test_generate_raises.py
+++ b/test/generator/generate_true/test_generate_raises.py
@@ -1,0 +1,10 @@
+from generator.generate_true.helpers import assert_generated_true
+from predicate import raises_exception_p, raises_p
+
+
+def test_generate_raises_p():
+    assert_generated_true(raises_p)
+
+
+def test_generate_raises_exception_p():
+    assert_generated_true(raises_exception_p(ValueError))

--- a/test/test_raises_predicate.py
+++ b/test/test_raises_predicate.py
@@ -58,3 +58,27 @@ def test_raises_p_false_parametrized(thunk):
 )
 def test_raises_p_true_parametrized(thunk):
     assert raises_p(thunk)
+
+
+async def _async_raises():
+    raise ValueError("async error")
+
+
+async def _async_no_raise():
+    return 42
+
+
+def test_raises_p_async_true():
+    assert raises_p(_async_raises)
+
+
+def test_raises_p_async_false():
+    assert not raises_p(_async_no_raise)
+
+
+def test_raises_exception_p_async_correct_type():
+    assert raises_exception_p(ValueError)(_async_raises)
+
+
+def test_raises_exception_p_async_wrong_type():
+    assert not raises_exception_p(TypeError)(_async_raises)

--- a/test/test_raises_predicate.py
+++ b/test/test_raises_predicate.py
@@ -1,0 +1,60 @@
+import pytest
+
+from predicate import raises_exception_p, raises_p
+
+
+def test_raises_p_true():
+    assert raises_p(lambda: 1 / 0)
+
+
+def test_raises_p_false():
+    assert not raises_p(lambda: 1)
+
+
+def test_raises_exception_p_correct_type():
+    assert raises_exception_p(ValueError)(lambda: int("x"))
+
+
+def test_raises_exception_p_wrong_type():
+    assert not raises_exception_p(ValueError)(lambda: 1 / 0)
+
+
+def test_raises_exception_p_no_exception():
+    assert not raises_exception_p(ValueError)(lambda: 1)
+
+
+def test_raises_exception_p_subclass():
+    assert raises_exception_p(Exception)(lambda: int("x"))
+
+
+def test_raises_p_repr():
+    assert repr(raises_p) == "raises_p"
+
+
+def test_raises_exception_p_repr():
+    predicate = raises_exception_p(ValueError)
+    assert repr(predicate) == "raises_exception_p(ValueError)"
+
+
+@pytest.mark.parametrize(
+    "thunk",
+    [
+        lambda: 1,
+        lambda: "foo",
+        lambda: None,
+    ],
+)
+def test_raises_p_false_parametrized(thunk):
+    assert not raises_p(thunk)
+
+
+@pytest.mark.parametrize(
+    "thunk",
+    [
+        lambda: 1 / 0,
+        lambda: int("x"),
+        lambda: [][0],
+    ],
+)
+def test_raises_p_true_parametrized(thunk):
+    assert raises_p(thunk)


### PR DESCRIPTION
Adds a predicate that returns True if a callable raises an exception:
- raises_p: singleton, matches any exception
- raises_exception_p(exc_type): factory for a specific exception type
- generate_true/generate_false support
- Tests for predicate behaviour and generators

Created with help from Claude Code