### PR TITLE
Fix correctness bugs in implies and add tests

### DIFF
--- a/predicate/generator/helpers.py
+++ b/predicate/generator/helpers.py
@@ -166,16 +166,7 @@ def random_dicts(
 
     while True:
         if (valid_size := next(valid_sizes)) >= 0:
-            if valid_size == 0:
-                yield {}
-                continue
-            d: dict = {}
-            for key in valid_keys:
-                if key not in d:
-                    d[key] = next(valid_values)
-                    if len(d) == valid_size:
-                        break
-            yield d
+            yield {k: next(valid_values) for k in take(valid_size, valid_keys)}
 
 
 def random_datetimes(lower: datetime | None = None, upper: datetime | None = None) -> Iterator:

--- a/predicate/generator/helpers.py
+++ b/predicate/generator/helpers.py
@@ -166,9 +166,16 @@ def random_dicts(
 
     while True:
         if (valid_size := next(valid_sizes)) >= 0:
-            keys = take(valid_size, valid_keys)
-            values = take(valid_size, valid_values)
-            yield dict(zip(keys, values, strict=False))
+            if valid_size == 0:
+                yield {}
+                continue
+            d: dict = {}
+            for key in valid_keys:
+                if key not in d:
+                    d[key] = next(valid_values)
+                    if len(d) == valid_size:
+                        break
+            yield d
 
 
 def random_datetimes(lower: datetime | None = None, upper: datetime | None = None) -> Iterator:

--- a/predicate/implies.py
+++ b/predicate/implies.py
@@ -50,7 +50,7 @@ def _(_predicate: AlwaysTruePredicate, other: Predicate) -> bool:
 
 @implies.register
 def _(predicate: AndPredicate, other: Predicate) -> bool:
-    return other == predicate.left or other == predicate.right
+    return implies(predicate.left, other) or implies(predicate.right, other)
 
 
 @implies.register
@@ -59,6 +59,8 @@ def _(predicate: GePredicate, other: Predicate) -> bool:
         case GePredicate(v):
             return predicate.v >= v
         case GtPredicate(v):
+            return predicate.v > v
+        case NePredicate(v):
             return predicate.v > v
         case _:
             return False
@@ -85,6 +87,8 @@ def _(predicate: LePredicate, other: Predicate) -> bool:
         case LePredicate(v):
             return predicate.v <= v
         case LtPredicate(v):
+            return predicate.v < v
+        case NePredicate(v):
             return predicate.v < v
         case _:
             return False
@@ -132,7 +136,7 @@ def _(predicate: EqPredicate, other: Predicate) -> bool:
 def _(predicate: IsRealSubsetPredicate, other: Predicate) -> bool:
     match other:
         case IsSubsetPredicate(v):
-            return predicate.v == v
+            return predicate.v <= v
         case _:
             return False
 
@@ -141,7 +145,7 @@ def _(predicate: IsRealSubsetPredicate, other: Predicate) -> bool:
 def _(predicate: IsRealSupersetPredicate, other: Predicate) -> bool:
     match other:
         case IsSupersetPredicate(v):
-            return predicate.v == v
+            return v <= predicate.v
         case _:
             return False
 

--- a/test/test_implies.py
+++ b/test/test_implies.py
@@ -37,10 +37,13 @@ def test_implies_ge_gt():
     assert implies(p, q)
 
 
-def test_implies_ge_other():
-    p = ge_p(3)
-
-    assert not implies(p, ne_p(2))
+def test_implies_ge_ne():
+    # x >= 3 implies x != 2 (since 2 < 3)
+    assert implies(ge_p(3), ne_p(2))
+    # x >= 3 does not imply x != 3 (since x could equal 3)
+    assert not implies(ge_p(3), ne_p(3))
+    # x >= 3 does not imply x != 4 (since x could equal 4)
+    assert not implies(ge_p(3), ne_p(4))
 
 
 def test_implies_ge_eq():
@@ -121,8 +124,11 @@ def test_implies_is_real_subset_false():
 def test_implies_is_real_super_superset():
     p = is_real_superset_p({1, 2, 3})
 
-    assert not implies(p, is_superset_p({1, 2}))
+    # proper superset of {1,2,3} is also a superset of {1,2}
+    assert implies(p, is_superset_p({1, 2}))
     assert implies(p, is_superset_p({1, 2, 3}))
+    # proper superset of {1,2,3} does not imply superset of {1,2,3,4}
+    assert not implies(p, is_superset_p({1, 2, 3, 4}))
 
 
 def test_implies_is_real_super_false():
@@ -136,3 +142,28 @@ def test_implies_in_in():
 
     assert not implies(p, in_p({1, 2}))
     assert implies(p, in_p({1, 2, 3, 4}))
+
+
+def test_implies_le_ne():
+    # x <= 5 implies x != 6 (since 6 > 5)
+    assert implies(le_p(5), ne_p(6))
+    # x <= 5 does not imply x != 5 (since x could equal 5)
+    assert not implies(le_p(5), ne_p(5))
+    # x <= 5 does not imply x != 4 (since x could equal 4)
+    assert not implies(le_p(5), ne_p(4))
+
+
+def test_implies_and_recursive():
+    # ge_p(5) & le_p(7) implies ge_p(3) because ge_p(5) implies ge_p(3)
+    assert implies(ge_p(5) & le_p(7), ge_p(3))
+    # ge_p(5) & le_p(7) implies le_p(9) because le_p(7) implies le_p(9)
+    assert implies(ge_p(5) & le_p(7), le_p(9))
+    # ge_p(5) & le_p(7) does not imply eq_p(6)
+    assert not implies(ge_p(5) & le_p(7), eq_p(6))
+
+
+def test_implies_is_real_subset_superset():
+    # proper subset of {1,2} is also a subset of {1,2,3}
+    assert implies(is_real_subset_p({1, 2}), is_subset_p({1, 2, 3}))
+    # proper subset of {1,2,3} does not imply subset of {1,2}
+    assert not implies(is_real_subset_p({1, 2, 3}), is_subset_p({1, 2}))


### PR DESCRIPTION
- AndPredicate dispatch now uses recursive implies instead of equality, so p & q => r when p => r or q => r
- GePredicate and LePredicate now handle NePredicate: ge_p(n) => ne_p(v) when v < n, le_p(n) => ne_p(v) when v > n
- IsRealSubsetPredicate and IsRealSupersetPredicate use subset checks instead of equality, covering the general case
- Add test_implies.py covering all fixed and new cases
- Fix random_dicts generator to avoid duplicate keys