### PR TITLE
Add predicate analysis and fix flakey tests (#191)

### DIFF
--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -5,6 +5,7 @@ __version__ = "1.6.0"
 from predicate.all_predicate import all_p
 from predicate.always_false_predicate import always_false_p, never_p
 from predicate.always_true_predicate import always_p, always_true_p
+from predicate.analysis import are_equivalent, is_satisfiable, is_tautology
 from predicate.any_predicate import any_p
 from predicate.comp_predicate import comp_p
 from predicate.count_predicate import count_p, exactly_one_p, exactly_zero_p
@@ -104,6 +105,9 @@ from predicate.tuple_of_predicate import is_tuple_of_p
 __all__ = [
     "PredicateError",
     "Spec",
+    "are_equivalent",
+    "is_satisfiable",
+    "is_tautology",
     "all_p",
     "always_false_p",
     "always_p",

--- a/predicate/analysis.py
+++ b/predicate/analysis.py
@@ -1,16 +1,19 @@
-from predicate.always_false_predicate import AlwaysFalsePredicate
-from predicate.always_true_predicate import AlwaysTruePredicate
-from predicate.optimizer.predicate_optimizer import optimize
 from predicate.predicate import Predicate
 
 
 def is_tautology(predicate: Predicate) -> bool:
     """Return True if the predicate is True for all possible inputs."""
+    from predicate.always_true_predicate import AlwaysTruePredicate
+    from predicate.optimizer.predicate_optimizer import optimize
+
     return isinstance(optimize(predicate), AlwaysTruePredicate)
 
 
 def is_satisfiable(predicate: Predicate) -> bool:
     """Return True if the predicate can be True for at least one input."""
+    from predicate.always_false_predicate import AlwaysFalsePredicate
+    from predicate.optimizer.predicate_optimizer import optimize
+
     return not isinstance(optimize(predicate), AlwaysFalsePredicate)
 
 

--- a/predicate/analysis.py
+++ b/predicate/analysis.py
@@ -1,0 +1,19 @@
+from predicate.always_false_predicate import AlwaysFalsePredicate
+from predicate.always_true_predicate import AlwaysTruePredicate
+from predicate.optimizer.predicate_optimizer import optimize
+from predicate.predicate import Predicate
+
+
+def is_tautology(predicate: Predicate) -> bool:
+    """Return True if the predicate is True for all possible inputs."""
+    return isinstance(optimize(predicate), AlwaysTruePredicate)
+
+
+def is_satisfiable(predicate: Predicate) -> bool:
+    """Return True if the predicate can be True for at least one input."""
+    return not isinstance(optimize(predicate), AlwaysFalsePredicate)
+
+
+def are_equivalent(p: Predicate, q: Predicate) -> bool:
+    """Return True if both predicates accept exactly the same values."""
+    return is_tautology(~(p ^ q))

--- a/predicate/formatter/from_json.py
+++ b/predicate/formatter/from_json.py
@@ -105,7 +105,7 @@ def from_json(data: dict[str, Any]) -> Predicate:
             return is_same_p(from_json(value["predicate"]))
         case "is_subclass":
             klasses = [_resolve_class(name) for name in value["klass"]]
-            return is_subclass_p(*klasses)
+            return is_subclass_p(tuple(klasses) if len(klasses) > 1 else klasses[0])
         case "is_subset":
             return is_subset_p(set(value["v"]))
         case "is_superset":

--- a/predicate/generator/helpers.py
+++ b/predicate/generator/helpers.py
@@ -167,7 +167,14 @@ def random_dicts(
 
     while True:
         if (valid_size := next(valid_sizes)) >= 0:
-            yield {k: next(valid_values) for k in take(valid_size, valid_keys)}
+            seen: set = set()
+            keys: list = []
+            while len(keys) < valid_size:
+                k = next(valid_keys)
+                if k not in seen:
+                    seen.add(k)
+                    keys.append(k)
+            yield {k: next(valid_values) for k in keys}
 
 
 def random_datetimes(lower: datetime | None = None, upper: datetime | None = None) -> Iterator:

--- a/test/formatter/test_from_json.py
+++ b/test/formatter/test_from_json.py
@@ -1,0 +1,125 @@
+import pytest
+
+from predicate import (
+    all_p,
+    always_false_p,
+    always_true_p,
+    any_p,
+    count_p,
+    eq_p,
+    exactly_n,
+    ge_le_p,
+    ge_lt_p,
+    ge_p,
+    gt_le_p,
+    gt_lt_p,
+    gt_p,
+    has_key_p,
+    has_length_p,
+    has_path_p,
+    implies_p,
+    in_p,
+    is_close_p,
+    is_dict_of_p,
+    is_falsy_p,
+    is_instance_p,
+    is_int_p,
+    is_list_of_p,
+    is_none_p,
+    is_not_none_p,
+    is_real_subset_p,
+    is_real_superset_p,
+    is_set_of_p,
+    is_str_p,
+    is_subclass_p,
+    is_subset_p,
+    is_superset_p,
+    is_truthy_p,
+    is_tuple_of_p,
+    juxt_p,
+    le_p,
+    lt_p,
+    match_p,
+    ne_p,
+    not_in_p,
+    optional,
+    regex_p,
+    to_json,
+)
+from predicate.formatter.from_json import from_json
+from predicate.is_same_predicate import is_same_p
+from predicate.named_predicate import NamedPredicate
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        always_false_p,
+        always_true_p,
+        all_p(is_int_p),
+        any_p(is_int_p),
+        always_true_p & always_false_p,
+        always_true_p | always_false_p,
+        always_true_p ^ always_false_p,
+        ~always_true_p,
+        count_p(is_int_p, eq_p(3)),
+        is_dict_of_p(("name", is_str_p)),
+        eq_p(42),
+        eq_p("hello"),
+        exactly_n(2, is_int_p),
+        ge_p(5),
+        ge_le_p(lower=1, upper=10),
+        ge_lt_p(lower=1, upper=10),
+        gt_p(5),
+        gt_le_p(lower=1, upper=10),
+        gt_lt_p(lower=1, upper=10),
+        has_key_p("key"),
+        has_length_p(eq_p(3)),
+        has_path_p(eq_p("a"), eq_p("b")),
+        implies_p(always_true_p),
+        in_p([1, 2, 3]),
+        is_close_p(1.0, rel_tol=1e-9, abs_tol=0.0),
+        is_falsy_p,
+        is_int_p,
+        is_instance_p(int, str),
+        is_none_p,
+        is_not_none_p,
+        is_real_subset_p({1, 2, 3}),
+        is_real_superset_p({1, 2, 3}),
+        is_same_p(always_true_p),
+        is_subclass_p(int),
+        is_subclass_p((int, str)),
+        is_subset_p({1, 2, 3}),
+        is_superset_p({1, 2, 3}),
+        is_truthy_p,
+        juxt_p(always_true_p, always_false_p, evaluate=all_p(always_true_p)),
+        le_p(10),
+        is_list_of_p(is_int_p),
+        lt_p(10),
+        match_p(is_int_p, is_str_p),
+        ne_p(7),
+        not_in_p([4, 5, 6]),
+        optional(is_int_p),
+        regex_p(r"\d+"),
+        is_set_of_p(is_int_p),
+        is_tuple_of_p(is_int_p, is_str_p),
+        NamedPredicate(name="x"),
+    ],
+)
+def test_from_json_round_trip(predicate):
+    assert from_json(to_json(predicate)) == predicate
+
+
+def test_from_json_reduce_raises():
+    with pytest.raises(ValueError, match="reduce_p cannot be deserialized from JSON"):
+        from_json({"reduce": {"fn": "my_fn", "initial": 0}})
+
+
+def test_from_json_unknown_key_raises():
+    with pytest.raises(ValueError, match="Unknown predicate type"):
+        from_json({"unknown_predicate_type": {}})
+
+
+def test_from_json_unknown_class_raises():
+    with pytest.raises(ValueError, match="Unknown class"):
+        from_json({"is_instance": {"klass": ["UnknownClass"]}})

--- a/test/spec/test_exercise_function.py
+++ b/test/spec/test_exercise_function.py
@@ -59,7 +59,7 @@ def test_exercise_with_fn_fail():
     }
 
     with pytest.raises(AssertionError) as exc:
-        list(exercise(max_int, spec=spec))
+        list(exercise(max_int, spec=spec, n=100))
 
     assert exc.value.args[0].startswith("Not conform spec: fn constraint failed for inputs")
 
@@ -81,7 +81,7 @@ def test_exercise_with_fn_p_fail():
     spec: Spec = {"args": {"x": is_int_p, "y": is_int_p}, "ret": is_int_p, "fn_p": lambda x, y: ge_p(x) & ge_p(y)}
 
     with pytest.raises(AssertionError) as exc:
-        list(exercise(max_int, spec=spec))
+        list(exercise(max_int, spec=spec, n=100))
 
     assert exc.value.args[0].startswith("Not conform spec:")
 
@@ -311,7 +311,7 @@ async def test_exercise_async_function_with_fn_fail():
     }
 
     with pytest.raises(AssertionError) as exc:
-        async for _ in exercise(max_int, spec=spec):
+        async for _ in exercise(max_int, spec=spec, n=100):
             pass
     assert exc.value.args[0].startswith("Not conform spec: fn constraint failed for inputs")
 
@@ -335,6 +335,6 @@ async def test_exercise_async_function_with_fn_p_fail():
     spec: Spec = {"args": {"x": is_int_p, "y": is_int_p}, "ret": is_int_p, "fn_p": lambda x, y: ge_p(x) & ge_p(y)}
 
     with pytest.raises(AssertionError) as exc:
-        async for _ in exercise(max_int, spec=spec):
+        async for _ in exercise(max_int, spec=spec, n=100):
             pass
     assert exc.value.args[0].startswith("Not conform spec:")

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -6,17 +6,26 @@ from predicate.range_predicate import ge_le_p
 
 
 @pytest.mark.parametrize(
-    "predicate, expected, description",
+    "predicate, description",
     [
-        (always_true_p, True, "always_true_p is a tautology"),
-        (always_false_p, False, "always_false_p is not a tautology"),
-        (is_int_p | ~is_int_p, True, "p | ~p is a tautology"),
-        (is_int_p, False, "is_int_p is not a tautology"),
-        (~(is_int_p & ~is_int_p), True, "~(p & ~p) is a tautology"),
+        (always_true_p, "always_true_p is a tautology"),
+        (is_int_p | ~is_int_p, "p | ~p is a tautology"),
+        (~(is_int_p & ~is_int_p), "~(p & ~p) is a tautology"),
     ],
 )
-def test_is_tautology(predicate, expected, description):
-    assert is_tautology(predicate) is expected, description
+def test_is_tautology(predicate, description):
+    assert is_tautology(predicate), description
+
+
+@pytest.mark.parametrize(
+    "predicate, description",
+    [
+        (always_false_p, "always_false_p is not a tautology"),
+        (is_int_p, "is_int_p is not a tautology"),
+    ],
+)
+def test_is_not_tautology(predicate, description):
+    assert not is_tautology(predicate), description
 
 
 @pytest.mark.parametrize(

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1,0 +1,60 @@
+import pytest
+
+from predicate import always_false_p, always_true_p, ge_p, is_int_p, is_str_p
+from predicate.analysis import are_equivalent, is_satisfiable, is_tautology
+from predicate.range_predicate import ge_le_p
+
+
+def test_is_tautology_always_true():
+    assert is_tautology(always_true_p)
+
+
+def test_is_tautology_always_false():
+    assert not is_tautology(always_false_p)
+
+
+def test_is_tautology_p_or_not_p():
+    assert is_tautology(is_int_p | ~is_int_p)
+
+
+def test_is_tautology_simple_predicate():
+    assert not is_tautology(is_int_p)
+
+
+def test_is_satisfiable_always_true():
+    assert is_satisfiable(always_true_p)
+
+
+def test_is_satisfiable_always_false():
+    assert not is_satisfiable(always_false_p)
+
+
+def test_is_satisfiable_contradiction():
+    assert not is_satisfiable(is_int_p & is_str_p)
+
+
+def test_is_satisfiable_simple_predicate():
+    assert is_satisfiable(is_int_p)
+
+
+def test_are_equivalent_same_predicate():
+    assert are_equivalent(is_int_p, is_int_p)
+
+
+def test_are_equivalent_range():
+    from predicate import le_p
+
+    assert are_equivalent(ge_le_p(lower=1, upper=5), ge_p(1) & le_p(5))
+
+
+@pytest.mark.parametrize(
+    "p, q, expected",
+    [
+        (always_true_p, always_true_p, True),
+        (always_false_p, always_false_p, True),
+        (always_true_p, always_false_p, False),
+        (is_int_p, is_str_p, False),
+    ],
+)
+def test_are_equivalent_parametrized(p, q, expected):
+    assert are_equivalent(p, q) is expected

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -29,28 +29,46 @@ def test_is_not_tautology(predicate, description):
 
 
 @pytest.mark.parametrize(
-    "predicate, expected, description",
+    "predicate, description",
     [
-        (always_true_p, True, "always_true_p is satisfiable"),
-        (always_false_p, False, "always_false_p is not satisfiable"),
-        (is_int_p & is_str_p, False, "int & str contradiction is not satisfiable"),
-        (is_int_p, True, "is_int_p is satisfiable"),
+        (always_true_p, "always_true_p is satisfiable"),
+        (is_int_p, "is_int_p is satisfiable"),
     ],
 )
-def test_is_satisfiable(predicate, expected, description):
-    assert is_satisfiable(predicate) is expected, description
+def test_is_satisfiable(predicate, description):
+    assert is_satisfiable(predicate), description
 
 
 @pytest.mark.parametrize(
-    "p, q, expected, description",
+    "predicate, description",
     [
-        (always_true_p, always_true_p, True, "always_true_p is equivalent to itself"),
-        (always_false_p, always_false_p, True, "always_false_p is equivalent to itself"),
-        (always_true_p, always_false_p, False, "always_true_p is not equivalent to always_false_p"),
-        (is_int_p, is_str_p, False, "is_int_p is not equivalent to is_str_p"),
-        (is_int_p, is_int_p, True, "is_int_p is equivalent to itself"),
-        (ge_le_p(lower=1, upper=5), ge_p(1) & le_p(5), True, "ge_le_p(1, 5) is equivalent to ge_p(1) & le_p(5)"),
+        (always_false_p, "always_false_p is not satisfiable"),
+        (is_int_p & is_str_p, "int & str contradiction is not satisfiable"),
     ],
 )
-def test_are_equivalent(p, q, expected, description):
-    assert are_equivalent(p, q) is expected, description
+def test_is_not_satisfiable(predicate, description):
+    assert not is_satisfiable(predicate), description
+
+
+@pytest.mark.parametrize(
+    "p, q, description",
+    [
+        (always_true_p, always_true_p, "always_true_p is equivalent to itself"),
+        (always_false_p, always_false_p, "always_false_p is equivalent to itself"),
+        (is_int_p, is_int_p, "is_int_p is equivalent to itself"),
+        (ge_le_p(lower=1, upper=5), ge_p(1) & le_p(5), "ge_le_p(1, 5) is equivalent to ge_p(1) & le_p(5)"),
+    ],
+)
+def test_are_equivalent(p, q, description):
+    assert are_equivalent(p, q), description
+
+
+@pytest.mark.parametrize(
+    "p, q, description",
+    [
+        (always_true_p, always_false_p, "always_true_p is not equivalent to always_false_p"),
+        (is_int_p, is_str_p, "is_int_p is not equivalent to is_str_p"),
+    ],
+)
+def test_are_not_equivalent(p, q, description):
+    assert not are_equivalent(p, q), description

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1,50 +1,35 @@
 import pytest
 
-from predicate import always_false_p, always_true_p, ge_p, is_int_p, is_str_p
+from predicate import always_false_p, always_true_p, ge_p, is_int_p, is_str_p, le_p
 from predicate.analysis import are_equivalent, is_satisfiable, is_tautology
 from predicate.range_predicate import ge_le_p
 
 
-def test_is_tautology_always_true():
-    assert is_tautology(always_true_p)
+@pytest.mark.parametrize(
+    "predicate, expected",
+    [
+        (always_true_p, True),
+        (always_false_p, False),
+        (is_int_p | ~is_int_p, True),
+        (is_int_p, False),
+        (~(is_int_p & ~is_int_p), True),
+    ],
+)
+def test_is_tautology(predicate, expected):
+    assert is_tautology(predicate) is expected
 
 
-def test_is_tautology_always_false():
-    assert not is_tautology(always_false_p)
-
-
-def test_is_tautology_p_or_not_p():
-    assert is_tautology(is_int_p | ~is_int_p)
-
-
-def test_is_tautology_simple_predicate():
-    assert not is_tautology(is_int_p)
-
-
-def test_is_satisfiable_always_true():
-    assert is_satisfiable(always_true_p)
-
-
-def test_is_satisfiable_always_false():
-    assert not is_satisfiable(always_false_p)
-
-
-def test_is_satisfiable_contradiction():
-    assert not is_satisfiable(is_int_p & is_str_p)
-
-
-def test_is_satisfiable_simple_predicate():
-    assert is_satisfiable(is_int_p)
-
-
-def test_are_equivalent_same_predicate():
-    assert are_equivalent(is_int_p, is_int_p)
-
-
-def test_are_equivalent_range():
-    from predicate import le_p
-
-    assert are_equivalent(ge_le_p(lower=1, upper=5), ge_p(1) & le_p(5))
+@pytest.mark.parametrize(
+    "predicate, expected",
+    [
+        (always_true_p, True),
+        (always_false_p, False),
+        (is_int_p & is_str_p, False),
+        (is_int_p, True),
+    ],
+)
+def test_is_satisfiable(predicate, expected):
+    assert is_satisfiable(predicate) is expected
 
 
 @pytest.mark.parametrize(
@@ -54,7 +39,9 @@ def test_are_equivalent_range():
         (always_false_p, always_false_p, True),
         (always_true_p, always_false_p, False),
         (is_int_p, is_str_p, False),
+        (is_int_p, is_int_p, True),
+        (ge_le_p(lower=1, upper=5), ge_p(1) & le_p(5), True),
     ],
 )
-def test_are_equivalent_parametrized(p, q, expected):
+def test_are_equivalent(p, q, expected):
     assert are_equivalent(p, q) is expected

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -6,42 +6,42 @@ from predicate.range_predicate import ge_le_p
 
 
 @pytest.mark.parametrize(
-    "predicate, expected",
+    "predicate, expected, description",
     [
-        (always_true_p, True),
-        (always_false_p, False),
-        (is_int_p | ~is_int_p, True),
-        (is_int_p, False),
-        (~(is_int_p & ~is_int_p), True),
+        (always_true_p, True, "always_true_p is a tautology"),
+        (always_false_p, False, "always_false_p is not a tautology"),
+        (is_int_p | ~is_int_p, True, "p | ~p is a tautology"),
+        (is_int_p, False, "is_int_p is not a tautology"),
+        (~(is_int_p & ~is_int_p), True, "~(p & ~p) is a tautology"),
     ],
 )
-def test_is_tautology(predicate, expected):
-    assert is_tautology(predicate) is expected
+def test_is_tautology(predicate, expected, description):
+    assert is_tautology(predicate) is expected, description
 
 
 @pytest.mark.parametrize(
-    "predicate, expected",
+    "predicate, expected, description",
     [
-        (always_true_p, True),
-        (always_false_p, False),
-        (is_int_p & is_str_p, False),
-        (is_int_p, True),
+        (always_true_p, True, "always_true_p is satisfiable"),
+        (always_false_p, False, "always_false_p is not satisfiable"),
+        (is_int_p & is_str_p, False, "int & str contradiction is not satisfiable"),
+        (is_int_p, True, "is_int_p is satisfiable"),
     ],
 )
-def test_is_satisfiable(predicate, expected):
-    assert is_satisfiable(predicate) is expected
+def test_is_satisfiable(predicate, expected, description):
+    assert is_satisfiable(predicate) is expected, description
 
 
 @pytest.mark.parametrize(
-    "p, q, expected",
+    "p, q, expected, description",
     [
-        (always_true_p, always_true_p, True),
-        (always_false_p, always_false_p, True),
-        (always_true_p, always_false_p, False),
-        (is_int_p, is_str_p, False),
-        (is_int_p, is_int_p, True),
-        (ge_le_p(lower=1, upper=5), ge_p(1) & le_p(5), True),
+        (always_true_p, always_true_p, True, "always_true_p is equivalent to itself"),
+        (always_false_p, always_false_p, True, "always_false_p is equivalent to itself"),
+        (always_true_p, always_false_p, False, "always_true_p is not equivalent to always_false_p"),
+        (is_int_p, is_str_p, False, "is_int_p is not equivalent to is_str_p"),
+        (is_int_p, is_int_p, True, "is_int_p is equivalent to itself"),
+        (ge_le_p(lower=1, upper=5), ge_p(1) & le_p(5), True, "ge_le_p(1, 5) is equivalent to ge_p(1) & le_p(5)"),
     ],
 )
-def test_are_equivalent(p, q, expected):
-    assert are_equivalent(p, q) is expected
+def test_are_equivalent(p, q, expected, description):
+    assert are_equivalent(p, q) is expected, description


### PR DESCRIPTION
## Summary

- Add `predicate/analysis.py` with `is_satisfiable`, `is_tautology`, and `are_equivalent` (closes #191)
- Export analysis functions from `predicate/__init__.py`
- Add `test/test_analysis.py` with parametrized positive/negative test pairs for all three functions
- Add `test/formatter/test_from_json.py` with 53 tests covering all `from_json` cases (round-trip + error cases)
- Fix bug in `from_json.py`: `is_subclass_p` with multiple classes was broken
- Fix flakey test in `random_dicts`: duplicate keys could produce dicts smaller than requested size
- Fix flakey exercise fn constraint tests: increase n from 10 to 100

## Test plan

- [ ] `python -m pytest test/test_analysis.py -v` — 15 tests pass
- [ ] `python -m pytest test/formatter/test_from_json.py -v` — 53 tests pass
- [ ] `python -m pytest test/ -x -q` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)