### PR TITLE
Raise predicate/spec test coverage to 100%

### DIFF
--- a/predicate/spec/exercise_helpers.py
+++ b/predicate/spec/exercise_helpers.py
@@ -13,7 +13,7 @@ from predicate.predicate import Predicate
 from predicate.spec.spec import Spec
 
 _type_narrowing_origins: set = {TypeGuard}
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 13):  # pragma: no cover
     from typing import TypeIs
 
     _type_narrowing_origins.add(TypeIs)

--- a/test/spec/test_exercise_class.py
+++ b/test/spec/test_exercise_class.py
@@ -1,6 +1,9 @@
+from typing import TypeGuard, TypeVar
+
 import pytest
 
 from predicate import ge_p, is_bool_p, is_float_p, is_int_p, pos_p, zero_p
+from predicate.predicate import Predicate
 from predicate.spec.exercise import Spec, exercise
 
 
@@ -157,6 +160,37 @@ def test_exercise_class_with_fn_p_fail():
     with pytest.raises(AssertionError) as exc:
         list(exercise(Doubler(), spec=spec))
     assert exc.value.args[0].startswith("Not conform spec:")
+
+
+def test_exercise_predicate_klass_not_implemented():
+    class MyPred(Predicate):
+        def __call__(self, x: int) -> bool:
+            return True
+
+        # no get_klass() override → .klass raises NotImplementedError
+
+    result = list(exercise(MyPred()))
+    assert result
+
+
+def test_exercise_class_typeguard_return():
+    class MyCallable:
+        def __call__(self, x: int) -> TypeGuard[int]:
+            return x > 0
+
+    result = list(exercise(MyCallable()))
+    assert result
+
+
+def test_exercise_class_typevar_param():
+    T = TypeVar("T")
+
+    class MyCallable:
+        def __call__(self, x: T) -> bool:
+            return True
+
+    result = list(exercise(MyCallable()))
+    assert result
 
 
 @pytest.mark.asyncio

--- a/test/spec/test_exercise_function.py
+++ b/test/spec/test_exercise_function.py
@@ -1,3 +1,5 @@
+from typing import TypeVar
+
 import pytest
 
 from predicate import ge_p, is_int_p, is_str_p, pos_p
@@ -325,6 +327,17 @@ async def test_exercise_async_function_with_fn_p():
 
     result = [r async for r in exercise(max_int, spec=spec)]
     assert result
+
+
+def test_exercise_function_typevar_param_not_in_spec():
+    T = TypeVar("T")
+
+    def identity(x: T) -> int:
+        return 0
+
+    spec: Spec = {"args": {}, "ret": is_int_p}
+    with pytest.raises(AssertionError, match="not in spec"):
+        list(exercise(identity, spec=spec))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add tests for previously uncovered branches: TypeGuard return annotation, TypeVar-annotated parameters, and Predicate subclasses where klass raises NotImplementedError. Mark the Python 3.13+ TypeIs block with pragma: no cover.

🤖 Created with help from [Claude Code](https://claude.com/claude-code)