### PR TITLE
Add raises key to Spec for exception handling in instrument

### DIFF
--- a/docs/instrumentation.rst
+++ b/docs/instrumentation.rst
@@ -53,6 +53,22 @@ Spec keys
 
         "fn_p": lambda x, y: ge_p(x + y)
 
+``raises`` *(optional)*
+    One exception type, or a tuple of exception types, that the function is allowed to raise.
+    When the function raises an exception that matches, it propagates to the caller normally.
+    When the function raises an exception that does *not* match, ``on_error`` is called and the
+    unexpected exception is re-raised.
+
+    If ``raises`` is absent and the function raises, the exception propagates unchanged — there
+    is no validation.
+
+    .. code-block:: python
+
+        "raises": ValueError
+
+        # or multiple types:
+        "raises": (ValueError, KeyError)
+
 Using the decorator
 -------------------
 
@@ -112,3 +128,132 @@ raises:
 
 Note that argument predicates are checked *before* the function executes, so no side effects
 occur when an argument is invalid.
+
+Specifying expected exceptions
+------------------------------
+
+Use the ``raises`` key to declare which exception types a function may raise:
+
+.. code-block:: python
+
+    from predicate import instrument, Spec, is_int_p
+
+    spec: Spec = {
+        "args": {"n": is_int_p},
+        "raises": ValueError,
+    }
+
+    @instrument(spec)
+    def checked_sqrt(n: int) -> float:
+        if n < 0:
+            raise ValueError(f"Cannot take square root of {n}")
+        return n ** 0.5
+
+Calling with a negative number re-raises the ``ValueError`` as expected:
+
+.. code-block:: python
+
+    checked_sqrt(-1)  # raises ValueError: Cannot take square root of -1
+
+If the function raises a *different* exception type, ``on_error`` is called first:
+
+.. code-block:: python
+
+    spec: Spec = {"args": {}, "raises": ValueError}
+
+    @instrument(spec)
+    def f() -> int:
+        raise TypeError("unexpected")
+
+    f()
+    # raises ValueError: Unexpected exception TypeError for function f
+    # followed by the original TypeError
+
+To allow several exception types, pass a tuple:
+
+.. code-block:: python
+
+    spec: Spec = {
+        "args": {"key": is_str_p},
+        "raises": (KeyError, ValueError),
+    }
+
+Async support
+-------------
+
+``instrument`` and ``instrument_function`` work transparently with ``async def`` functions.
+The same spec keys apply; argument checking happens before the coroutine is awaited and
+return / constraint checking happens after:
+
+.. code-block:: python
+
+    import asyncio
+    from predicate import instrument, Spec, is_int_p, ge_p
+
+    spec: Spec = {
+        "args": {"x": is_int_p, "y": is_int_p},
+        "ret": is_int_p,
+        "fn": lambda x, y, ret: ret >= x and ret >= y,
+    }
+
+    @instrument(spec)
+    async def async_max(x: int, y: int) -> int:
+        return x if x >= y else y
+
+    result = asyncio.run(async_max(3, 7))  # returns 7
+
+Async functions that raise are handled identically to sync functions — use the ``raises``
+key in the spec to declare expected exception types:
+
+.. code-block:: python
+
+    spec: Spec = {
+        "args": {"key": is_str_p},
+        "raises": KeyError,
+    }
+
+    @instrument(spec)
+    async def fetch(key: str) -> str:
+        raise KeyError(key)
+
+    asyncio.run(fetch("missing"))  # raises KeyError as expected
+
+Instrumenting whole modules
+---------------------------
+
+``instrument_module`` applies an empty spec (derived entirely from annotations) to every
+function in a module:
+
+.. code-block:: python
+
+    import mymodule
+    from predicate import instrument_module
+
+    instrument_module(mymodule)
+
+An optional ``pattern`` argument (fnmatch-style) limits which functions are instrumented:
+
+.. code-block:: python
+
+    instrument_module(mymodule, pattern="get_*")
+
+Custom error handling
+---------------------
+
+By default, spec violations raise ``ValueError``. Pass ``on_error`` to override:
+
+.. code-block:: python
+
+    import logging
+
+    errors = []
+
+    @instrument(on_error=errors.append)
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    add("oops", 1)       # on_error called, but function still runs
+    print(errors)        # ['Parameter predicate for function add failed. Reason: ...']
+
+The same ``on_error`` parameter is accepted by ``instrument_function`` and
+``instrument_module``.

--- a/docs/instrumentation.rst
+++ b/docs/instrumentation.rst
@@ -173,6 +173,8 @@ To allow several exception types, pass a tuple:
 
 .. code-block:: python
 
+    from predicate import instrument, Spec, is_str_p
+
     spec: Spec = {
         "args": {"key": is_str_p},
         "raises": (KeyError, ValueError),
@@ -188,7 +190,7 @@ return / constraint checking happens after:
 .. code-block:: python
 
     import asyncio
-    from predicate import instrument, Spec, is_int_p, ge_p
+    from predicate import instrument, Spec, is_int_p
 
     spec: Spec = {
         "args": {"x": is_int_p, "y": is_int_p},
@@ -206,6 +208,8 @@ Async functions that raise are handled identically to sync functions — use the
 key in the spec to declare expected exception types:
 
 .. code-block:: python
+
+    from predicate import instrument, Spec, is_str_p
 
     spec: Spec = {
         "args": {"key": is_str_p},
@@ -244,7 +248,7 @@ By default, spec violations raise ``ValueError``. Pass ``on_error`` to override:
 
 .. code-block:: python
 
-    import logging
+    from predicate import instrument
 
     errors = []
 

--- a/predicate/spec/instrument.py
+++ b/predicate/spec/instrument.py
@@ -59,6 +59,14 @@ def _check_return_value(spec: Spec, func_name: str, result: Any) -> str | None:
     return None
 
 
+def _check_exception(spec: Spec, func_name: str, exc: Exception) -> str | None:
+    if expected := spec.get("raises"):
+        if not isinstance(exc, expected):
+            return f"Unexpected exception {type(exc).__name__} for function {func_name}"
+        return None
+    return None
+
+
 def _check_constraints(spec: Spec, func_name: str, arguments: dict, result: Any) -> str | None:
     if fn := spec.get("fn"):
         if not fn(**arguments, ret=result):
@@ -88,7 +96,12 @@ def instrument_function(func: Callable, spec: Spec, on_error: OnError = _default
             if error := _check_args(spec, func_name, arguments):
                 on_error(error)
 
-            result = await func(*args, **kwargs)
+            try:
+                result = await func(*args, **kwargs)
+            except Exception as exc:
+                if error := _check_exception(spec, func_name, exc):
+                    on_error(error)
+                raise
 
             if error := _check_return_value(spec, func_name, result):
                 on_error(error)
@@ -108,7 +121,12 @@ def instrument_function(func: Callable, spec: Spec, on_error: OnError = _default
             if error := _check_args(spec, func_name, arguments):
                 on_error(error)
 
-            result = func(*args, **kwargs)
+            try:
+                result = func(*args, **kwargs)
+            except Exception as exc:
+                if error := _check_exception(spec, func_name, exc):
+                    on_error(error)
+                raise
 
             if error := _check_return_value(spec, func_name, result):
                 on_error(error)

--- a/predicate/spec/spec.py
+++ b/predicate/spec/spec.py
@@ -9,5 +9,6 @@ Spec = TypedDict(
         "ret": NotRequired[Predicate],
         "fn": NotRequired[Callable[..., bool]],
         "fn_p": NotRequired[Callable[..., Predicate]],
+        "raises": NotRequired[type[Exception] | tuple[type[Exception], ...]],
     },
 )

--- a/test/spec/test_instrument.py
+++ b/test/spec/test_instrument.py
@@ -425,3 +425,44 @@ def test_instrument_module_with_on_error():
 
     assert len(errors) == 1
     assert "Parameter predicate for function greet failed" in errors[0]
+
+
+def test_instrument_raises_expected_exception() -> None:
+    spec: Spec = {"args": {}, "raises": ValueError}
+
+    @instrument(spec)
+    def f(x: int) -> int:
+        raise ValueError("bad input")
+
+    with pytest.raises(ValueError, match="bad input"):
+        f(1)
+
+
+def test_instrument_raises_unexpected_exception() -> None:
+    spec: Spec = {"args": {}, "raises": ValueError}
+
+    @instrument(spec)
+    def f(x: int) -> int:
+        raise TypeError("wrong type")
+
+    with pytest.raises(ValueError, match="Unexpected exception TypeError for function f"):
+        f(1)
+
+
+def test_instrument_raises_no_spec_propagates() -> None:
+    @instrument
+    def f(x: int) -> int:
+        raise RuntimeError("oops")
+
+    with pytest.raises(RuntimeError, match="oops"):
+        f(1)
+
+
+def test_instrument_raises_not_raised_validates_return() -> None:
+    spec: Spec = {"args": {}, "raises": ValueError}
+
+    @instrument(spec)
+    def f(x: int) -> int:
+        return x * 2
+
+    assert f(3) == 6


### PR DESCRIPTION
Allows users to declare expected exception types in a spec. When an instrumented function raises, instrument validates the exception against the declared type(s) and calls on_error for unexpected exceptions.