### PR TITLE
Kill surviving mutations with relational tests and exercise

### DIFF
--- a/test/generator/test_generate_predicate.py
+++ b/test/generator/test_generate_predicate.py
@@ -9,6 +9,10 @@ from predicate.ge_predicate import GePredicate
 from predicate.generator.generate_predicate import (
     generate_all_predicates,
     generate_any_predicates,
+    generate_ge_le_predicates,
+    generate_ge_lt_predicates,
+    generate_gt_le_predicates,
+    generate_gt_lt_predicates,
     generate_predicate,
     generate_set_of_predicates,
 )
@@ -121,6 +125,19 @@ def test_generate_set_of_predicate(klass):
     for predicate in predicates:
         assert isinstance(predicate, predicate_type)
         assert is_klass_predicate(predicate)
+
+
+@pytest.mark.parametrize(
+    "generate_func",
+    [generate_ge_le_predicates, generate_ge_lt_predicates, generate_gt_le_predicates, generate_gt_lt_predicates],
+)
+def test_generate_range_predicates_are_callable(generate_func):
+    predicates = take(10, generate_func(max_depth=1, klass=int))
+    assert predicates
+    for predicate in predicates:
+        # Calling the predicate must not raise — upper=None would cause TypeError
+        assert isinstance(predicate(predicate.lower), bool)
+        assert isinstance(predicate(predicate.upper), bool)
 
 
 def test_generate_any_predicates_depth_zero():

--- a/test/optimizer/test_predicate_optimizer.py
+++ b/test/optimizer/test_predicate_optimizer.py
@@ -10,6 +10,12 @@ from predicate import (
 )
 
 
+def test_can_optimize_returns_false_for_leaf():
+    from predicate import eq_p
+
+    assert can_optimize(eq_p(2)) is False
+
+
 def test_optimize_not_or(p):
     # ~(p | ~p) == False
 

--- a/test/test_dict_of_predicate.py
+++ b/test/test_dict_of_predicate.py
@@ -90,3 +90,8 @@ def test_is_dict_of_explain_not_a_dict():
 
     expected = {"reason": "3 is not an instance of a dict", "result": False}
     assert explain(predicate, 3) == expected
+
+
+def test_is_dict_of_p_repr_with_predicate_key():
+    predicate = is_dict_of_p((is_str_p, is_int_p))
+    assert "is_str_p" in repr(predicate)

--- a/test/test_eq_predicate.py
+++ b/test/test_eq_predicate.py
@@ -2,7 +2,7 @@ import pytest
 from helpers import exercise_predicate
 from more_itertools import one
 
-from predicate import eq_p
+from predicate import eq_p, exercise, is_int_p
 from predicate.consumes import consumes
 from predicate.explain import explain
 
@@ -43,6 +43,11 @@ def test_eq_str():
 
 def test_eq_exercise():
     exercise_predicate(eq_p)
+
+
+def test_eq_p_relational():
+    spec = {"args": {"v": is_int_p}, "fn": lambda v, ret: ret(v) and not ret(v + 1)}
+    assert list(exercise(eq_p, spec=spec, n=20))
 
 
 @pytest.mark.parametrize("iterable, expected_end", [([], 0), ([1, 2], 0), ([2, 1], 1)])

--- a/test/test_fn_predicate.py
+++ b/test/test_fn_predicate.py
@@ -1,6 +1,11 @@
 import math
 
-from predicate import explain, fn_p, is_finite_p, is_inf_p, is_not_none_p
+import pytest
+
+from predicate import eq_p, explain, fn_p, is_finite_p, is_inf_p, is_int_p, is_not_none_p, is_str_p, or_p
+from predicate.fn_predicate import generate_inf, undefined
+from predicate.match_predicate import match_p
+from predicate.predicate import predicate_partial
 
 
 def test_fn_p_with_lambda():
@@ -43,3 +48,28 @@ def test_is_inf_p():
 
     assert is_inf_p(-math.inf)
     assert is_inf_p(math.inf)
+
+
+def test_undefined_raises_with_message():
+    with pytest.raises(ValueError, match=r"^Please register generator type$"):
+        undefined()
+
+
+def test_generate_inf_first_value_is_negative():
+    assert next(generate_inf()) == -math.inf
+
+
+def test_predicate_partial():
+    partial_or = predicate_partial(or_p, eq_p(1))
+    combined = partial_or(eq_p(2))
+    assert combined(1)
+    assert combined(2)
+    assert not combined(3)
+
+
+def test_predicate_partial_with_kwargs():
+    # full_match=True kwarg must be preserved; dropping **kwargs makes full_match=False (default)
+    partial_match = predicate_partial(match_p, is_int_p, full_match=True)
+    predicate = partial_match(is_str_p)
+    assert predicate([1, "foo"])
+    assert not predicate([1, "foo", "bar"])  # "bar" leftover, only caught with full_match=True

--- a/test/test_ge_predicate.py
+++ b/test/test_ge_predicate.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from uuid import UUID
 
+import pytest
 from helpers import exercise_predicate
 
 from predicate import ge_p
@@ -66,3 +67,10 @@ def test_ge_explain():
 
 def test_ge_exercise():
     exercise_predicate(ge_p)
+
+
+@pytest.mark.parametrize("v", range(-3, 4))
+def test_ge_p_boundary(v):
+    pred = ge_p(v)
+    assert pred(v)
+    assert not pred(v - 1)

--- a/test/test_gt_predicate.py
+++ b/test/test_gt_predicate.py
@@ -2,6 +2,7 @@ import math
 from datetime import datetime, timedelta
 from uuid import UUID
 
+import pytest
 from helpers import exercise_predicate
 
 from predicate import gt_p, pos_p
@@ -66,6 +67,13 @@ def test_gt_explain():
 
 def test_gt_exercise():
     exercise_predicate(gt_p)
+
+
+@pytest.mark.parametrize("v", range(-3, 4))
+def test_gt_p_boundary(v):
+    pred = gt_p(v)
+    assert not pred(v)
+    assert pred(v + 1)
 
 
 def test_pos_p():

--- a/test/test_has_path_predicate.py
+++ b/test/test_has_path_predicate.py
@@ -1,4 +1,4 @@
-from predicate import eq_p, explain, ge_p, has_path_p
+from predicate import eq_p, explain, ge_p, has_path_p, is_str_p
 from predicate.standard_predicates import is_int_p, is_list_p
 
 
@@ -40,6 +40,12 @@ def test_has_path_predicate_with_list():
     predicate = has_path_p(has_x, is_list_p, has_y, ge_2)
 
     assert predicate({"x": [{"y": 13}]})
+
+
+def test_has_path_predicate_list_first_pred_fails():
+    # first_p(list) is False, but individual elements match — result must be False (and, not or)
+    predicate = has_path_p(eq_p("x"), is_str_p, is_int_p)
+    assert not predicate({"x": [1, 2]})
 
 
 # def test_has_path_predicate_with_nested_x():

--- a/test/test_is_close_predicate.py
+++ b/test/test_is_close_predicate.py
@@ -55,5 +55,15 @@ def test_is_close_to_yaml():
     assert "target" in result
 
 
+def test_is_close_p_default_rel_tol():
+    predicate = is_close_p(1.0)
+    assert predicate.rel_tol == 1e-9
+
+
+def test_is_close_p_default_abs_tol():
+    predicate = is_close_p(1.0)
+    assert predicate.abs_tol == 0.0
+
+
 def test_is_close_exercise():
     exercise_predicate(is_close_p)

--- a/test/test_le_predicate.py
+++ b/test/test_le_predicate.py
@@ -1,3 +1,4 @@
+import pytest
 from helpers import exercise_predicate
 
 from predicate import le_p
@@ -21,3 +22,10 @@ def test_le_explain():
 
 def test_le_exercise():
     exercise_predicate(le_p)
+
+
+@pytest.mark.parametrize("v", range(-3, 4))
+def test_le_p_boundary(v):
+    pred = le_p(v)
+    assert pred(v)
+    assert not pred(v + 1)

--- a/test/test_lt_predicate.py
+++ b/test/test_lt_predicate.py
@@ -1,5 +1,6 @@
 import math
 
+import pytest
 from helpers import exercise_predicate
 
 from predicate import lt_p, neg_p
@@ -22,6 +23,13 @@ def test_lt_explain():
 
 def test_lt_exercise():
     exercise_predicate(lt_p)
+
+
+@pytest.mark.parametrize("v", range(-3, 4))
+def test_lt_p_boundary(v):
+    pred = lt_p(v)
+    assert not pred(v)
+    assert pred(v - 1)
 
 
 def test_neg_p():

--- a/test/test_match_predicate.py
+++ b/test/test_match_predicate.py
@@ -23,6 +23,11 @@ from predicate.match_predicate import match_p
 from predicate.star_predicate import wildcard
 
 
+def test_match_p_default_full_match():
+    predicate = match_p(is_int_p)
+    assert not predicate.full_match
+
+
 def test_match_first():
     predicate = match_p(is_int_p)
 
@@ -195,6 +200,18 @@ def test_repeat_and_exactly_and_repeat():
     assert predicate([1, 2, 3.0, "foo", "bar"])
 
     assert repr(predicate) == "match_p(repeat(1, 3, is_int_p), is_float_p, repeat(2, 3, is_str_p))"
+
+
+def test_match_star_full_match():
+    # With full_match=True, star followed by is_str_p must consume the entire iterable.
+    # [1, "foo", "bar"] should fail because "bar" is leftover after star+str match.
+    predicate = match_p(star(is_int_p), is_str_p, full_match=True)
+
+    assert predicate([1, "foo"])
+    assert not predicate([1, "foo", "bar"])
+
+    result = explain(predicate, [1, "foo", "bar"])
+    assert result["result"] is False
 
 
 def test_match_star():

--- a/test/test_named_predicate.py
+++ b/test/test_named_predicate.py
@@ -40,3 +40,11 @@ def test_to_named_predicate_not():
     predicate = to_named_predicate(~eq_2)
 
     assert predicate == ~NamedPredicate(name="p1")
+
+
+def test_to_named_predicate_not_preserves_inner_predicate():
+    # ~eq_p(2) & ~eq_p(3) must name the inner predicates independently.
+    # If the inner predicate is replaced with None both nots share the same
+    # name, giving ~p1 & ~p1 instead of the correct ~p1 & ~p2.
+    predicate = to_named_predicate(~eq_p(2) & ~eq_p(3))
+    assert predicate == ~NamedPredicate(name="p1") & ~NamedPredicate(name="p2")

--- a/test/test_ne_predicate.py
+++ b/test/test_ne_predicate.py
@@ -1,7 +1,7 @@
 import pytest
 from helpers import exercise_predicate
 
-from predicate import ne_p
+from predicate import exercise, is_int_p, ne_p
 from predicate.explain import explain
 
 
@@ -21,3 +21,9 @@ def test_eq_explain():
 
 def test_ne_exercise():
     exercise_predicate(ne_p)
+
+
+def test_ne_p_relational():
+    # ne_p(v)(x) is True iff x != v; so ret(v)=False but ret(v+1)=True
+    spec = {"args": {"v": is_int_p}, "fn": lambda v, ret: not ret(v) and ret(v + 1)}
+    assert list(exercise(ne_p, spec=spec, n=20))

--- a/test/test_root_predicate.py
+++ b/test/test_root_predicate.py
@@ -27,6 +27,14 @@ def test_root_predicate_dont_call():
         root_p(13)
 
 
+def test_root_predicate_not_found():
+    from predicate.root_predicate import RootPredicate
+
+    rp = RootPredicate()
+    with pytest.raises(ValueError, match=r"^Could not find 'root' predicate$"):
+        rp(13)
+
+
 def test_root_explain():
     str_or_list_of_str = is_str_p | is_list_of_p(root_p)
 

--- a/test/test_standard_predicates.py
+++ b/test/test_standard_predicates.py
@@ -1,0 +1,15 @@
+from predicate.standard_predicates import dict_depth
+
+
+def test_dict_depth_empty_list():
+    assert dict_depth([]) == 0
+
+
+def test_dict_depth_int_list():
+    # 1 (list) + max(dict_depth(1)) = 1 + 1 = 2
+    assert dict_depth([1, 2]) == 2
+
+
+def test_dict_depth_nested_list():
+    # 1 (list) + max(dict_depth({"a": 1})) = 1 + (1 + dict_depth(1)) = 1 + 2 = 3
+    assert dict_depth([{"a": 1}]) == 3

--- a/test/test_str_predicates.py
+++ b/test/test_str_predicates.py
@@ -12,6 +12,7 @@ from predicate import (
     is_upper_p,
     starts_with_p,
 )
+from predicate.str_predicates import create_is_str_p
 
 
 def test_is_alnum_p():
@@ -79,3 +80,9 @@ def test_starts_with_p():
 
     assert not predicate("bar")
     assert predicate("foobar")
+
+
+def test_create_is_str_p():
+    pred = create_is_str_p(str.isupper)
+    assert pred("ABC")
+    assert not pred("abc")

--- a/test/test_truth_table.py
+++ b/test/test_truth_table.py
@@ -26,14 +26,14 @@ def test_truth_table_names(p, q):
 def test_truth_table_names_invalid(p, q):
     predicate = p & q & le_p(2)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^Type not allowed"):
         get_named_predicates(predicate)
 
 
 def test_truth_table_values_invalid(p, q):
     predicate = p & q & le_p(2)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^Type not allowed"):
         values = {"p": True, "q": True}
         set_named_values(predicate, values)
 


### PR DESCRIPTION
Add boundary tests to comparison predicate files using exercise with fn constraints (eq_p, ne_p) and parametrized boundary checks (ge_p, gt_p, le_p, lt_p). Add callability test for range predicate generators to kill upper=None mutations in generate_predicate.py.