### PR TITLE
Add compile_predicate: compile predicate trees to native callables (#10)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ jobs:
           gh-pages-branch: benchmark-results
           benchmark-data-dir-path: benchmarks
           # Alert on 20% regression; post a PR comment and fail the check
-          alert-threshold: "120%"
+          alert-threshold: "150%"
           comment-on-alert: true
           fail-on-alert: true
           # Always post a summary comment on PRs even without a regression

--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -8,6 +8,7 @@ from predicate.always_true_predicate import always_p, always_true_p
 from predicate.analysis import are_equivalent, is_satisfiable, is_tautology
 from predicate.any_predicate import any_p
 from predicate.comp_predicate import comp_p
+from predicate.compile_predicate import CompiledPredicate, NotCompilableError, compile_predicate, try_compile_predicate
 from predicate.count_predicate import count_p, exactly_one_p, exactly_zero_p
 from predicate.dict_of_predicate import is_dict_of_p
 from predicate.eq_predicate import eq_false_p, eq_p, eq_true_p, zero_p
@@ -125,7 +126,10 @@ __all__ = [
     "and_p",
     "any_p",
     "can_optimize",
+    "compile_predicate",
+    "CompiledPredicate",
     "comp_p",
+    "NotCompilableError",
     "count_p",
     "eq_false_p",
     "eq_p",
@@ -259,6 +263,7 @@ __all__ = [
     "starts_with_p",
     "tee_p",
     "this_p",
+    "try_compile_predicate",
     "to_dot",
     "to_json",
     "to_latex",

--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -12,8 +12,8 @@ from predicate.count_predicate import count_p, exactly_one_p, exactly_zero_p
 from predicate.dict_of_predicate import is_dict_of_p
 from predicate.eq_predicate import eq_false_p, eq_p, eq_true_p, zero_p
 from predicate.exactly_predicate import exactly_n
-from predicate.exception_predicate import PredicateError, exception_p
-from predicate.compile_predicate import CompiledPredicate, NotCompilableError, compile_predicate, try_compile_predicate
+from predicate.exception_predicate import exception_p
+from predicate.compile_predicate import compile_predicate, try_compile_predicate
 from predicate.explain import explain
 from predicate.fn_predicate import fn_p, is_even_p, is_finite_p, is_inf_p, is_nan_p, is_odd_p
 from predicate.formatter import to_dot, to_json, to_latex, to_yaml
@@ -73,7 +73,7 @@ from predicate.optimizer.predicate_optimizer import can_optimize, optimize
 from predicate.optional_predicate import optional
 from predicate.plus_predicate import plus
 from predicate.predicate import and_p, or_p, xor_p
-from predicate.raises_predicate import RaisesPredicate, raises_exception_p, raises_p
+from predicate.raises_predicate import raises_exception_p, raises_p
 from predicate.range_predicate import ge_le_p, ge_lt_p, gt_le_p, gt_lt_p
 from predicate.recur_predicate import recur_p
 from predicate.reduce_predicate import reduce_p
@@ -81,7 +81,6 @@ from predicate.regex_predicate import regex_p
 from predicate.repeat_predicate import repeat
 from predicate.set_of_predicate import is_set_of_p
 from predicate.set_predicates import (
-    IntersectsPredicate,
     intersects_p,
     is_real_subset_p,
     is_real_superset_p,
@@ -96,7 +95,6 @@ from predicate.spec.instrument import (
     instrument_module,
     is_instrumented,
 )
-from predicate.spec.spec import Spec
 from predicate.standard_predicates import (
     is_dict_p,
     is_float_p,
@@ -114,8 +112,6 @@ from predicate.tee_predicate import tee_p
 from predicate.tuple_of_predicate import is_tuple_of_p
 
 __all__ = [
-    "PredicateError",
-    "Spec",
     "are_equivalent",
     "is_satisfiable",
     "is_tautology",
@@ -127,9 +123,7 @@ __all__ = [
     "any_p",
     "can_optimize",
     "compile_predicate",
-    "CompiledPredicate",
     "comp_p",
-    "NotCompilableError",
     "count_p",
     "eq_false_p",
     "eq_p",
@@ -155,7 +149,6 @@ __all__ = [
     "has_path_p",
     "implies_p",
     "in_p",
-    "IntersectsPredicate",
     "intersects_p",
     "instrument",
     "instrument_class",
@@ -253,7 +246,6 @@ __all__ = [
     "pos_p",
     "recur_p",
     "reduce_p",
-    "RaisesPredicate",
     "raises_exception_p",
     "raises_p",
     "regex_p",

--- a/predicate/__init__.py
+++ b/predicate/__init__.py
@@ -8,12 +8,12 @@ from predicate.always_true_predicate import always_p, always_true_p
 from predicate.analysis import are_equivalent, is_satisfiable, is_tautology
 from predicate.any_predicate import any_p
 from predicate.comp_predicate import comp_p
-from predicate.compile_predicate import CompiledPredicate, NotCompilableError, compile_predicate, try_compile_predicate
 from predicate.count_predicate import count_p, exactly_one_p, exactly_zero_p
 from predicate.dict_of_predicate import is_dict_of_p
 from predicate.eq_predicate import eq_false_p, eq_p, eq_true_p, zero_p
 from predicate.exactly_predicate import exactly_n
 from predicate.exception_predicate import PredicateError, exception_p
+from predicate.compile_predicate import CompiledPredicate, NotCompilableError, compile_predicate, try_compile_predicate
 from predicate.explain import explain
 from predicate.fn_predicate import fn_p, is_even_p, is_finite_p, is_inf_p, is_nan_p, is_odd_p
 from predicate.formatter import to_dot, to_json, to_latex, to_yaml

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -354,21 +354,16 @@ def _(predicate: TupleOfPredicate, namespace: dict) -> ast.expr:
     if n == 0:
         return len_check
 
-    element_checks = []
-    for i, p in enumerate(predicate.predicates):
-        try:
-            inner_fn = compile_predicate(p).fn
-        except NotCompilableError:
-            inner_fn = p
+    def element_check(i: int, p: Predicate) -> ast.expr:
         key = f"_p{len(namespace)}"
-        namespace[key] = inner_fn
-        element_checks.append(
-            ast.Call(
-                func=ast.Name(id=key, ctx=ast.Load()),
-                args=[ast.Subscript(value=_x(), slice=_const(i), ctx=ast.Load())],
-                keywords=[],
-            )
+        namespace[key] = try_compile_predicate(p)
+        return ast.Call(
+            func=ast.Name(id=key, ctx=ast.Load()),
+            args=[ast.Subscript(value=_x(), slice=_const(i), ctx=ast.Load())],
+            keywords=[],
         )
+
+    element_checks = [element_check(i, p) for i, p in enumerate(predicate.predicates)]
     return ast.BoolOp(op=ast.And(), values=[len_check, *element_checks])
 
 

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -291,24 +291,24 @@ def _(predicate: AnyPredicate, namespace: dict) -> ast.expr:
     return _any_all_ast(predicate.predicate, "any", namespace)
 
 
-def _isinstance_and_all_ast(predicate: Predicate, type_name: str, namespace: dict) -> ast.expr:
+def _isinstance_and_all_ast(inner: Predicate, type_name: str, namespace: dict) -> ast.expr:
     isinstance_check = ast.Call(
         func=_name("isinstance"),
         args=[_x(), _name(type_name)],
         keywords=[],
     )
-    all_check = _any_all_ast(predicate.predicate, "all", namespace)
+    all_check = _any_all_ast(inner, "all", namespace)
     return ast.BoolOp(op=ast.And(), values=[isinstance_check, all_check])
 
 
 @_to_ast.register
 def _(predicate: ListOfPredicate, namespace: dict) -> ast.expr:
-    return _isinstance_and_all_ast(predicate, "list", namespace)
+    return _isinstance_and_all_ast(predicate.predicate, "list", namespace)
 
 
 @_to_ast.register
 def _(predicate: SetOfPredicate, namespace: dict) -> ast.expr:
-    return _isinstance_and_all_ast(predicate, "set", namespace)
+    return _isinstance_and_all_ast(predicate.predicate, "set", namespace)
 
 
 @_to_ast.register

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -3,9 +3,24 @@
 import ast
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from functools import singledispatch
 from typing import override
 
-from predicate.predicate import Predicate
+from predicate.eq_predicate import EqPredicate
+from predicate.ge_predicate import GePredicate
+from predicate.gt_predicate import GtPredicate
+from predicate.in_predicate import InPredicate
+from predicate.is_falsy_predicate import IsFalsyPredicate
+from predicate.is_instance_predicate import IsInstancePredicate
+from predicate.is_none_predicate import IsNonePredicate
+from predicate.is_not_none_predicate import IsNotNonePredicate
+from predicate.is_truthy_predicate import IsTruthyPredicate
+from predicate.le_predicate import LePredicate
+from predicate.lt_predicate import LtPredicate
+from predicate.ne_predicate import NePredicate
+from predicate.not_in_predicate import NotInPredicate
+from predicate.predicate import AndPredicate, NotPredicate, OrPredicate, Predicate, XorPredicate
+from predicate.range_predicate import GeLePredicate, GeLtPredicate, GtLePredicate, GtLtPredicate
 
 
 class NotCompilableError(Exception):
@@ -46,94 +61,159 @@ class CompiledPredicate[T](Predicate[T]):
         return self.predicate.klass
 
 
-def _to_ast(predicate: Predicate, namespace: dict) -> ast.expr:  # noqa: C901
-    from predicate.eq_predicate import EqPredicate
-    from predicate.ge_predicate import GePredicate
-    from predicate.gt_predicate import GtPredicate
-    from predicate.in_predicate import InPredicate
-    from predicate.is_falsy_predicate import IsFalsyPredicate
-    from predicate.is_instance_predicate import IsInstancePredicate
-    from predicate.is_none_predicate import IsNonePredicate
-    from predicate.is_not_none_predicate import IsNotNonePredicate
-    from predicate.is_truthy_predicate import IsTruthyPredicate
-    from predicate.le_predicate import LePredicate
-    from predicate.lt_predicate import LtPredicate
-    from predicate.ne_predicate import NePredicate
-    from predicate.not_in_predicate import NotInPredicate
-    from predicate.predicate import AndPredicate, NotPredicate, OrPredicate, XorPredicate
-    from predicate.range_predicate import GeLePredicate, GeLtPredicate, GtLePredicate, GtLtPredicate
+def _x() -> ast.Name:
+    return ast.Name(id="x", ctx=ast.Load())
 
-    x = ast.Name(id="x", ctx=ast.Load())
 
-    def _const(v) -> ast.Constant:
-        return ast.Constant(value=v)
+def _const(v) -> ast.Constant:
+    return ast.Constant(value=v)
 
-    def _cmp(ops: list, comparators: list) -> ast.Compare:
-        return ast.Compare(left=x, ops=ops, comparators=comparators)
 
-    def _delegate(p: Predicate) -> ast.Call:
-        key = f"_p{len(namespace)}"
-        namespace[key] = p
-        return ast.Call(func=ast.Name(id=key, ctx=ast.Load()), args=[x], keywords=[])
+def _cmp(ops: list, comparators: list) -> ast.Compare:
+    return ast.Compare(left=_x(), ops=ops, comparators=comparators)
 
-    match predicate:
-        case EqPredicate(v):
-            return _cmp([ast.Eq()], [_const(v)])
-        case NePredicate(v):
-            return _cmp([ast.NotEq()], [_const(v)])
-        case GtPredicate(v):
-            return _cmp([ast.Gt()], [_const(v)])
-        case GePredicate(v):
-            return _cmp([ast.GtE()], [_const(v)])
-        case LtPredicate(v):
-            return _cmp([ast.Lt()], [_const(v)])
-        case LePredicate(v):
-            return _cmp([ast.LtE()], [_const(v)])
-        case IsNonePredicate():
-            return _cmp([ast.Is()], [_const(None)])
-        case IsNotNonePredicate():
-            return _cmp([ast.IsNot()], [_const(None)])
-        case IsTruthyPredicate():
-            return ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[x], keywords=[])
-        case IsFalsyPredicate():
-            return ast.UnaryOp(
-                op=ast.Not(),
-                operand=ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[x], keywords=[]),
-            )
-        case InPredicate(v) if isinstance(v, Iterable):
-            key = f"_s{len(namespace)}"
-            namespace[key] = frozenset(v)
-            return _cmp([ast.In()], [ast.Name(id=key, ctx=ast.Load())])
-        case NotInPredicate(v) if isinstance(v, Iterable):
-            key = f"_s{len(namespace)}"
-            namespace[key] = frozenset(v)
-            return _cmp([ast.NotIn()], [ast.Name(id=key, ctx=ast.Load())])
-        case GeLePredicate(lower, upper):
-            return ast.Compare(left=_const(lower), ops=[ast.LtE(), ast.LtE()], comparators=[x, _const(upper)])
-        case GeLtPredicate(lower, upper):
-            return ast.Compare(left=_const(lower), ops=[ast.LtE(), ast.Lt()], comparators=[x, _const(upper)])
-        case GtLePredicate(lower, upper):
-            return ast.Compare(left=_const(lower), ops=[ast.Lt(), ast.LtE()], comparators=[x, _const(upper)])
-        case GtLtPredicate(lower, upper):
-            return ast.Compare(left=_const(lower), ops=[ast.Lt(), ast.Lt()], comparators=[x, _const(upper)])
-        case IsInstancePredicate():
-            # Delegate to preserve special bool/int and generic-type semantics.
-            return _delegate(predicate)
-        case AndPredicate(left, right):
-            return ast.BoolOp(op=ast.And(), values=[_to_ast(left, namespace), _to_ast(right, namespace)])
-        case OrPredicate(left, right):
-            return ast.BoolOp(op=ast.Or(), values=[_to_ast(left, namespace), _to_ast(right, namespace)])
-        case NotPredicate(p):
-            return ast.UnaryOp(op=ast.Not(), operand=_to_ast(p, namespace))
-        case XorPredicate(left, right):
-            # bool(left_expr) ^ bool(right_expr)
-            bool_left = ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[_to_ast(left, namespace)], keywords=[])
-            bool_right = ast.Call(
-                func=ast.Name(id="bool", ctx=ast.Load()), args=[_to_ast(right, namespace)], keywords=[]
-            )
-            return ast.BinOp(left=bool_left, op=ast.BitXor(), right=bool_right)
-        case _:
-            raise NotCompilableError(f"Cannot compile predicate of type {type(predicate).__name__}")
+
+def _delegate(predicate: Predicate, namespace: dict) -> ast.Call:
+    key = f"_p{len(namespace)}"
+    namespace[key] = predicate
+    return ast.Call(func=ast.Name(id=key, ctx=ast.Load()), args=[_x()], keywords=[])
+
+
+@singledispatch
+def _to_ast(predicate: Predicate, namespace: dict) -> ast.expr:
+    raise NotCompilableError(f"Cannot compile predicate of type {type(predicate).__name__}")
+
+
+@_to_ast.register
+def _(predicate: EqPredicate, namespace: dict) -> ast.expr:
+    return _cmp([ast.Eq()], [_const(predicate.v)])
+
+
+@_to_ast.register
+def _(predicate: NePredicate, namespace: dict) -> ast.expr:
+    return _cmp([ast.NotEq()], [_const(predicate.v)])
+
+
+@_to_ast.register
+def _(predicate: GtPredicate, namespace: dict) -> ast.expr:
+    return _cmp([ast.Gt()], [_const(predicate.v)])
+
+
+@_to_ast.register
+def _(predicate: GePredicate, namespace: dict) -> ast.expr:
+    return _cmp([ast.GtE()], [_const(predicate.v)])
+
+
+@_to_ast.register
+def _(predicate: LtPredicate, namespace: dict) -> ast.expr:
+    return _cmp([ast.Lt()], [_const(predicate.v)])
+
+
+@_to_ast.register
+def _(predicate: LePredicate, namespace: dict) -> ast.expr:
+    return _cmp([ast.LtE()], [_const(predicate.v)])
+
+
+@_to_ast.register
+def _(predicate: IsNonePredicate, namespace: dict) -> ast.expr:
+    return _cmp([ast.Is()], [_const(None)])
+
+
+@_to_ast.register
+def _(predicate: IsNotNonePredicate, namespace: dict) -> ast.expr:
+    return _cmp([ast.IsNot()], [_const(None)])
+
+
+@_to_ast.register
+def _(predicate: IsTruthyPredicate, namespace: dict) -> ast.expr:
+    return ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[_x()], keywords=[])
+
+
+@_to_ast.register
+def _(predicate: IsFalsyPredicate, namespace: dict) -> ast.expr:
+    return ast.UnaryOp(
+        op=ast.Not(),
+        operand=ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[_x()], keywords=[]),
+    )
+
+
+@_to_ast.register
+def _(predicate: InPredicate, namespace: dict) -> ast.expr:
+    if not isinstance(predicate.v, Iterable):
+        raise NotCompilableError(f"Cannot compile InPredicate with non-iterable value {predicate.v!r}")
+    key = f"_s{len(namespace)}"
+    namespace[key] = frozenset(predicate.v)
+    return _cmp([ast.In()], [ast.Name(id=key, ctx=ast.Load())])
+
+
+@_to_ast.register
+def _(predicate: NotInPredicate, namespace: dict) -> ast.expr:
+    if not isinstance(predicate.v, Iterable):
+        raise NotCompilableError(f"Cannot compile NotInPredicate with non-iterable value {predicate.v!r}")
+    key = f"_s{len(namespace)}"
+    namespace[key] = frozenset(predicate.v)
+    return _cmp([ast.NotIn()], [ast.Name(id=key, ctx=ast.Load())])
+
+
+@_to_ast.register
+def _(predicate: GeLePredicate, namespace: dict) -> ast.expr:
+    return ast.Compare(
+        left=_const(predicate.lower), ops=[ast.LtE(), ast.LtE()], comparators=[_x(), _const(predicate.upper)]
+    )
+
+
+@_to_ast.register
+def _(predicate: GeLtPredicate, namespace: dict) -> ast.expr:
+    return ast.Compare(
+        left=_const(predicate.lower), ops=[ast.LtE(), ast.Lt()], comparators=[_x(), _const(predicate.upper)]
+    )
+
+
+@_to_ast.register
+def _(predicate: GtLePredicate, namespace: dict) -> ast.expr:
+    return ast.Compare(
+        left=_const(predicate.lower), ops=[ast.Lt(), ast.LtE()], comparators=[_x(), _const(predicate.upper)]
+    )
+
+
+@_to_ast.register
+def _(predicate: GtLtPredicate, namespace: dict) -> ast.expr:
+    return ast.Compare(
+        left=_const(predicate.lower), ops=[ast.Lt(), ast.Lt()], comparators=[_x(), _const(predicate.upper)]
+    )
+
+
+@_to_ast.register
+def _(predicate: IsInstancePredicate, namespace: dict) -> ast.expr:
+    # Delegate to preserve special bool/int and generic-type semantics.
+    return _delegate(predicate, namespace)
+
+
+@_to_ast.register
+def _(predicate: AndPredicate, namespace: dict) -> ast.expr:
+    return ast.BoolOp(op=ast.And(), values=[_to_ast(predicate.left, namespace), _to_ast(predicate.right, namespace)])
+
+
+@_to_ast.register
+def _(predicate: OrPredicate, namespace: dict) -> ast.expr:
+    return ast.BoolOp(op=ast.Or(), values=[_to_ast(predicate.left, namespace), _to_ast(predicate.right, namespace)])
+
+
+@_to_ast.register
+def _(predicate: NotPredicate, namespace: dict) -> ast.expr:
+    return ast.UnaryOp(op=ast.Not(), operand=_to_ast(predicate.predicate, namespace))
+
+
+@_to_ast.register
+def _(predicate: XorPredicate, namespace: dict) -> ast.expr:
+    # bool(left_expr) ^ bool(right_expr)
+    bool_left = ast.Call(
+        func=ast.Name(id="bool", ctx=ast.Load()), args=[_to_ast(predicate.left, namespace)], keywords=[]
+    )
+    bool_right = ast.Call(
+        func=ast.Name(id="bool", ctx=ast.Load()), args=[_to_ast(predicate.right, namespace)], keywords=[]
+    )
+    return ast.BinOp(left=bool_left, op=ast.BitXor(), right=bool_right)
 
 
 def compile_predicate[T](predicate: Predicate[T]) -> CompiledPredicate[T]:

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -7,6 +7,7 @@ from functools import singledispatch
 from typing import override
 
 from predicate.all_predicate import AllPredicate
+from predicate.any_predicate import AnyPredicate
 from predicate.eq_predicate import EqPredicate
 from predicate.ge_predicate import GePredicate
 from predicate.gt_predicate import GtPredicate
@@ -219,8 +220,10 @@ def _(predicate: XorPredicate, namespace: dict) -> ast.expr:
 
 @_to_ast.register
 def _(predicate: AllPredicate, namespace: dict) -> ast.expr:
-    # Compile the inner predicate to its raw fn if possible, else fall back to the original.
-    # This avoids the CompiledPredicate.__call__ wrapper overhead per element.
+    return _any_all_ast(predicate, "all", namespace)
+
+
+def _any_all_ast(predicate: AllPredicate | AnyPredicate, fn_name: str, namespace: dict) -> ast.expr:
     try:
         inner_fn = compile_predicate(predicate.predicate).fn
     except NotCompilableError:
@@ -245,13 +248,18 @@ def _(predicate: AllPredicate, namespace: dict) -> ast.expr:
             )
         ],
     )
-    return ast.Call(func=ast.Name(id="all", ctx=ast.Load()), args=[gen], keywords=[])
+    return ast.Call(func=ast.Name(id=fn_name, ctx=ast.Load()), args=[gen], keywords=[])
+
+
+@_to_ast.register
+def _(predicate: AnyPredicate, namespace: dict) -> ast.expr:
+    return _any_all_ast(predicate, "any", namespace)
 
 
 def compile_predicate[T](predicate: Predicate[T]) -> CompiledPredicate[T]:
     """Compile a predicate to a native callable for faster evaluation.
 
-    Raises NotCompilableError for unsupported predicate types (any_p, fn_p, regex_p, etc.).
+    Raises NotCompilableError for unsupported predicate types (fn_p, regex_p, etc.).
     """
     namespace: dict = {}
     body = _to_ast(predicate, namespace)

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -18,6 +18,7 @@ from predicate.is_none_predicate import IsNonePredicate
 from predicate.is_not_none_predicate import IsNotNonePredicate
 from predicate.is_truthy_predicate import IsTruthyPredicate
 from predicate.le_predicate import LePredicate
+from predicate.list_of_predicate import ListOfPredicate
 from predicate.lt_predicate import LtPredicate
 from predicate.ne_predicate import NePredicate
 from predicate.not_in_predicate import NotInPredicate
@@ -254,6 +255,18 @@ def _any_all_ast(predicate: AllPredicate | AnyPredicate, fn_name: str, namespace
 @_to_ast.register
 def _(predicate: AnyPredicate, namespace: dict) -> ast.expr:
     return _any_all_ast(predicate, "any", namespace)
+
+
+@_to_ast.register
+def _(predicate: ListOfPredicate, namespace: dict) -> ast.expr:
+    # isinstance(x, list) and all(_p0(_e) for _e in x)
+    isinstance_check = ast.Call(
+        func=ast.Name(id="isinstance", ctx=ast.Load()),
+        args=[_x(), ast.Name(id="list", ctx=ast.Load())],
+        keywords=[],
+    )
+    all_check = _any_all_ast(predicate, "all", namespace)
+    return ast.BoolOp(op=ast.And(), values=[isinstance_check, all_check])
 
 
 def compile_predicate[T](predicate: Predicate[T]) -> CompiledPredicate[T]:

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -13,6 +13,7 @@ from predicate.any_predicate import AnyPredicate
 from predicate.eq_predicate import EqPredicate
 from predicate.ge_predicate import GePredicate
 from predicate.gt_predicate import GtPredicate
+from predicate.has_key_predicate import HasKeyPredicate
 from predicate.in_predicate import InPredicate
 from predicate.is_falsy_predicate import IsFalsyPredicate
 from predicate.is_instance_predicate import IsInstancePredicate
@@ -26,6 +27,7 @@ from predicate.ne_predicate import NePredicate
 from predicate.not_in_predicate import NotInPredicate
 from predicate.predicate import AndPredicate, NotPredicate, OrPredicate, Predicate, XorPredicate
 from predicate.range_predicate import GeLePredicate, GeLtPredicate, GtLePredicate, GtLtPredicate
+from predicate.set_of_predicate import SetOfPredicate
 
 
 class NotCompilableError(Exception):
@@ -171,6 +173,17 @@ def _(predicate: NotInPredicate, namespace: dict) -> ast.expr:
 
 
 @_to_ast.register
+def _(predicate: HasKeyPredicate, namespace: dict) -> ast.expr:
+    key = f"_k{len(namespace)}"
+    namespace[key] = predicate.key
+    return ast.Compare(
+        left=ast.Name(id=key, ctx=ast.Load()),
+        ops=[ast.In()],
+        comparators=[_x()],
+    )
+
+
+@_to_ast.register
 def _(predicate: GeLePredicate, namespace: dict) -> ast.expr:
     return ast.Compare(
         left=_const(predicate.lower), ops=[ast.LtE(), ast.LtE()], comparators=[_x(), _const(predicate.upper)]
@@ -269,16 +282,24 @@ def _(predicate: AnyPredicate, namespace: dict) -> ast.expr:
     return _any_all_ast(predicate, "any", namespace)
 
 
-@_to_ast.register
-def _(predicate: ListOfPredicate, namespace: dict) -> ast.expr:
-    # isinstance(x, list) and all(_p0(_e) for _e in x)
+def _isinstance_and_all_ast(predicate: Predicate, type_name: str, namespace: dict) -> ast.expr:
     isinstance_check = ast.Call(
         func=ast.Name(id="isinstance", ctx=ast.Load()),
-        args=[_x(), ast.Name(id="list", ctx=ast.Load())],
+        args=[_x(), ast.Name(id=type_name, ctx=ast.Load())],
         keywords=[],
     )
     all_check = _any_all_ast(predicate, "all", namespace)
     return ast.BoolOp(op=ast.And(), values=[isinstance_check, all_check])
+
+
+@_to_ast.register
+def _(predicate: ListOfPredicate, namespace: dict) -> ast.expr:
+    return _isinstance_and_all_ast(predicate, "list", namespace)
+
+
+@_to_ast.register
+def _(predicate: SetOfPredicate, namespace: dict) -> ast.expr:
+    return _isinstance_and_all_ast(predicate, "set", namespace)
 
 
 def compile_predicate[T](predicate: Predicate[T]) -> CompiledPredicate[T]:

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -1,0 +1,171 @@
+"""Compile predicates to native Python callables for faster evaluation."""
+
+import ast
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import override
+
+from predicate.predicate import Predicate
+
+
+class NotCompilableError(Exception):
+    """Raised when a predicate cannot be compiled to a native callable."""
+
+
+@dataclass
+class CompiledPredicate[T](Predicate[T]):
+    """A predicate that delegates evaluation to a compiled native callable.
+
+    Preserves full introspection (repr, count, explain_failure, contains) via
+    the wrapped predicate. Only __call__ is replaced with the compiled fast path.
+    """
+
+    predicate: Predicate[T]
+    fn: Callable[[T], bool] = field(compare=False, repr=False)
+
+    def __call__(self, x: T) -> bool:
+        return self.fn(x)
+
+    def __repr__(self) -> str:
+        return repr(self.predicate)
+
+    def __contains__(self, p: object) -> bool:
+        return p in self.predicate  # type: ignore[operator]
+
+    @override
+    @property
+    def count(self) -> int:
+        return self.predicate.count
+
+    @override
+    def explain_failure(self, x: T) -> dict:
+        return self.predicate.explain_failure(x)
+
+    @override
+    def get_klass(self) -> type:
+        return self.predicate.klass
+
+
+def _to_ast(predicate: Predicate, namespace: dict) -> ast.expr:  # noqa: C901
+    from predicate.eq_predicate import EqPredicate
+    from predicate.ge_predicate import GePredicate
+    from predicate.gt_predicate import GtPredicate
+    from predicate.in_predicate import InPredicate
+    from predicate.is_falsy_predicate import IsFalsyPredicate
+    from predicate.is_instance_predicate import IsInstancePredicate
+    from predicate.is_none_predicate import IsNonePredicate
+    from predicate.is_not_none_predicate import IsNotNonePredicate
+    from predicate.is_truthy_predicate import IsTruthyPredicate
+    from predicate.le_predicate import LePredicate
+    from predicate.lt_predicate import LtPredicate
+    from predicate.ne_predicate import NePredicate
+    from predicate.not_in_predicate import NotInPredicate
+    from predicate.predicate import AndPredicate, NotPredicate, OrPredicate, XorPredicate
+    from predicate.range_predicate import GeLePredicate, GeLtPredicate, GtLePredicate, GtLtPredicate
+
+    x = ast.Name(id="x", ctx=ast.Load())
+
+    def _const(v) -> ast.Constant:
+        return ast.Constant(value=v)
+
+    def _cmp(ops: list, comparators: list) -> ast.Compare:
+        return ast.Compare(left=x, ops=ops, comparators=comparators)
+
+    def _delegate(p: Predicate) -> ast.Call:
+        key = f"_p{len(namespace)}"
+        namespace[key] = p
+        return ast.Call(func=ast.Name(id=key, ctx=ast.Load()), args=[x], keywords=[])
+
+    match predicate:
+        case EqPredicate(v):
+            return _cmp([ast.Eq()], [_const(v)])
+        case NePredicate(v):
+            return _cmp([ast.NotEq()], [_const(v)])
+        case GtPredicate(v):
+            return _cmp([ast.Gt()], [_const(v)])
+        case GePredicate(v):
+            return _cmp([ast.GtE()], [_const(v)])
+        case LtPredicate(v):
+            return _cmp([ast.Lt()], [_const(v)])
+        case LePredicate(v):
+            return _cmp([ast.LtE()], [_const(v)])
+        case IsNonePredicate():
+            return _cmp([ast.Is()], [_const(None)])
+        case IsNotNonePredicate():
+            return _cmp([ast.IsNot()], [_const(None)])
+        case IsTruthyPredicate():
+            return ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[x], keywords=[])
+        case IsFalsyPredicate():
+            return ast.UnaryOp(
+                op=ast.Not(),
+                operand=ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[x], keywords=[]),
+            )
+        case InPredicate(v) if isinstance(v, Iterable):
+            key = f"_s{len(namespace)}"
+            namespace[key] = frozenset(v)
+            return _cmp([ast.In()], [ast.Name(id=key, ctx=ast.Load())])
+        case NotInPredicate(v) if isinstance(v, Iterable):
+            key = f"_s{len(namespace)}"
+            namespace[key] = frozenset(v)
+            return _cmp([ast.NotIn()], [ast.Name(id=key, ctx=ast.Load())])
+        case GeLePredicate(lower, upper):
+            return ast.Compare(left=_const(lower), ops=[ast.LtE(), ast.LtE()], comparators=[x, _const(upper)])
+        case GeLtPredicate(lower, upper):
+            return ast.Compare(left=_const(lower), ops=[ast.LtE(), ast.Lt()], comparators=[x, _const(upper)])
+        case GtLePredicate(lower, upper):
+            return ast.Compare(left=_const(lower), ops=[ast.Lt(), ast.LtE()], comparators=[x, _const(upper)])
+        case GtLtPredicate(lower, upper):
+            return ast.Compare(left=_const(lower), ops=[ast.Lt(), ast.Lt()], comparators=[x, _const(upper)])
+        case IsInstancePredicate():
+            # Delegate to preserve special bool/int and generic-type semantics.
+            return _delegate(predicate)
+        case AndPredicate(left, right):
+            return ast.BoolOp(op=ast.And(), values=[_to_ast(left, namespace), _to_ast(right, namespace)])
+        case OrPredicate(left, right):
+            return ast.BoolOp(op=ast.Or(), values=[_to_ast(left, namespace), _to_ast(right, namespace)])
+        case NotPredicate(p):
+            return ast.UnaryOp(op=ast.Not(), operand=_to_ast(p, namespace))
+        case XorPredicate(left, right):
+            # bool(left_expr) ^ bool(right_expr)
+            bool_left = ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[_to_ast(left, namespace)], keywords=[])
+            bool_right = ast.Call(
+                func=ast.Name(id="bool", ctx=ast.Load()), args=[_to_ast(right, namespace)], keywords=[]
+            )
+            return ast.BinOp(left=bool_left, op=ast.BitXor(), right=bool_right)
+        case _:
+            raise NotCompilableError(f"Cannot compile predicate of type {type(predicate).__name__}")
+
+
+def compile_predicate[T](predicate: Predicate[T]) -> CompiledPredicate[T]:
+    """Compile a predicate to a native callable for faster evaluation.
+
+    Raises NotCompilableError for unsupported predicate types (all_p, any_p, fn_p, regex_p, etc.).
+    """
+    namespace: dict = {}
+    body = _to_ast(predicate, namespace)
+
+    lambda_ast = ast.Expression(
+        body=ast.Lambda(
+            args=ast.arguments(
+                posonlyargs=[],
+                args=[ast.arg(arg="x")],
+                vararg=None,
+                kwonlyargs=[],
+                kw_defaults=[],
+                kwarg=None,
+                defaults=[],
+            ),
+            body=body,
+        )
+    )
+    ast.fix_missing_locations(lambda_ast)
+    fn = eval(compile(lambda_ast, "<compiled_predicate>", "eval"), namespace)  # noqa: S307
+    return CompiledPredicate(predicate=predicate, fn=fn)
+
+
+def try_compile_predicate[T](predicate: Predicate[T]) -> Predicate[T]:
+    """Compile a predicate if possible, otherwise return the original unchanged."""
+    try:
+        return compile_predicate(predicate)
+    except NotCompilableError:
+        return predicate

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -16,6 +16,7 @@ from predicate.eq_predicate import EqPredicate
 from predicate.ge_predicate import GePredicate
 from predicate.gt_predicate import GtPredicate
 from predicate.has_key_predicate import HasKeyPredicate
+from predicate.has_length_predicate import HasLengthPredicate
 from predicate.in_predicate import InPredicate
 from predicate.is_close_predicate import IsClosePredicate
 from predicate.is_falsy_predicate import IsFalsyPredicate
@@ -195,6 +196,31 @@ def _(predicate: HasKeyPredicate, namespace: dict) -> ast.expr:
         ops=[ast.In()],
         comparators=[_x()],
     )
+
+
+@_to_ast.register
+def _(predicate: HasLengthPredicate, namespace: dict) -> ast.expr:
+    # _length_p(sum(1 for _ in x))
+    length_key = f"_p{len(namespace)}"
+    namespace[length_key] = try_compile_predicate(predicate.length_p)
+    count_expr = ast.Call(
+        func=_name("sum"),
+        args=[
+            ast.GeneratorExp(
+                elt=_const(1),
+                generators=[
+                    ast.comprehension(
+                        target=ast.Name(id="_", ctx=ast.Store()),
+                        iter=_x(),
+                        ifs=[],
+                        is_async=0,
+                    )
+                ],
+            )
+        ],
+        keywords=[],
+    )
+    return ast.Call(func=_name(length_key), args=[count_expr], keywords=[])
 
 
 @_to_ast.register

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -7,6 +7,8 @@ from functools import singledispatch
 from typing import override
 
 from predicate.all_predicate import AllPredicate
+from predicate.always_false_predicate import AlwaysFalsePredicate
+from predicate.always_true_predicate import AlwaysTruePredicate
 from predicate.any_predicate import AnyPredicate
 from predicate.eq_predicate import EqPredicate
 from predicate.ge_predicate import GePredicate
@@ -85,6 +87,16 @@ def _delegate(predicate: Predicate, namespace: dict) -> ast.Call:
 @singledispatch
 def _to_ast(predicate: Predicate, namespace: dict) -> ast.expr:
     raise NotCompilableError(f"Cannot compile predicate of type {type(predicate).__name__}")
+
+
+@_to_ast.register
+def _(predicate: AlwaysTruePredicate, namespace: dict) -> ast.expr:
+    return _const(True)
+
+
+@_to_ast.register
+def _(predicate: AlwaysFalsePredicate, namespace: dict) -> ast.expr:
+    return _const(False)
 
 
 @_to_ast.register

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from functools import singledispatch
 from typing import override
 
+from predicate.all_predicate import AllPredicate
 from predicate.eq_predicate import EqPredicate
 from predicate.ge_predicate import GePredicate
 from predicate.gt_predicate import GtPredicate
@@ -216,10 +217,41 @@ def _(predicate: XorPredicate, namespace: dict) -> ast.expr:
     return ast.BinOp(left=bool_left, op=ast.BitXor(), right=bool_right)
 
 
+@_to_ast.register
+def _(predicate: AllPredicate, namespace: dict) -> ast.expr:
+    # Compile the inner predicate to its raw fn if possible, else fall back to the original.
+    # This avoids the CompiledPredicate.__call__ wrapper overhead per element.
+    try:
+        inner_fn = compile_predicate(predicate.predicate).fn
+    except NotCompilableError:
+        inner_fn = predicate.predicate
+
+    inner_key = f"_p{len(namespace)}"
+    namespace[inner_key] = inner_fn
+
+    loop_var = "_e"
+    gen = ast.GeneratorExp(
+        elt=ast.Call(
+            func=ast.Name(id=inner_key, ctx=ast.Load()),
+            args=[ast.Name(id=loop_var, ctx=ast.Load())],
+            keywords=[],
+        ),
+        generators=[
+            ast.comprehension(
+                target=ast.Name(id=loop_var, ctx=ast.Store()),
+                iter=_x(),
+                ifs=[],
+                is_async=0,
+            )
+        ],
+    )
+    return ast.Call(func=ast.Name(id="all", ctx=ast.Load()), args=[gen], keywords=[])
+
+
 def compile_predicate[T](predicate: Predicate[T]) -> CompiledPredicate[T]:
     """Compile a predicate to a native callable for faster evaluation.
 
-    Raises NotCompilableError for unsupported predicate types (all_p, any_p, fn_p, regex_p, etc.).
+    Raises NotCompilableError for unsupported predicate types (any_p, fn_p, regex_p, etc.).
     """
     namespace: dict = {}
     body = _to_ast(predicate, namespace)

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -255,14 +255,14 @@ def _(predicate: XorPredicate, namespace: dict) -> ast.expr:
 
 @_to_ast.register
 def _(predicate: AllPredicate, namespace: dict) -> ast.expr:
-    return _any_all_ast(predicate, "all", namespace)
+    return _any_all_ast(predicate.predicate, "all", namespace)
 
 
-def _any_all_ast(predicate: AllPredicate | AnyPredicate, fn_name: str, namespace: dict) -> ast.expr:
+def _any_all_ast(inner: Predicate, fn_name: str, namespace: dict) -> ast.expr:
     try:
-        inner_fn = compile_predicate(predicate.predicate).fn
+        inner_fn = compile_predicate(inner).fn
     except NotCompilableError:
-        inner_fn = predicate.predicate
+        inner_fn = inner
 
     inner_key = f"_p{len(namespace)}"
     namespace[inner_key] = inner_fn
@@ -288,7 +288,7 @@ def _any_all_ast(predicate: AllPredicate | AnyPredicate, fn_name: str, namespace
 
 @_to_ast.register
 def _(predicate: AnyPredicate, namespace: dict) -> ast.expr:
-    return _any_all_ast(predicate, "any", namespace)
+    return _any_all_ast(predicate.predicate, "any", namespace)
 
 
 def _isinstance_and_all_ast(predicate: Predicate, type_name: str, namespace: dict) -> ast.expr:
@@ -297,7 +297,7 @@ def _isinstance_and_all_ast(predicate: Predicate, type_name: str, namespace: dic
         args=[_x(), _name(type_name)],
         keywords=[],
     )
-    all_check = _any_all_ast(predicate, "all", namespace)
+    all_check = _any_all_ast(predicate.predicate, "all", namespace)
     return ast.BoolOp(op=ast.And(), values=[isinstance_check, all_check])
 
 

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -11,6 +11,7 @@ from predicate.always_false_predicate import AlwaysFalsePredicate
 from predicate.always_true_predicate import AlwaysTruePredicate
 from predicate.any_predicate import AnyPredicate
 from predicate.comp_predicate import CompPredicate
+from predicate.count_predicate import CountPredicate
 from predicate.eq_predicate import EqPredicate
 from predicate.ge_predicate import GePredicate
 from predicate.gt_predicate import GtPredicate
@@ -341,6 +342,34 @@ def _(predicate: CompPredicate, namespace: dict) -> ast.expr:
         args=[ast.Call(func=_name(fn_key), args=[_x()], keywords=[])],
         keywords=[],
     )
+
+
+@_to_ast.register
+def _(predicate: CountPredicate, namespace: dict) -> ast.expr:
+    # sum(1 for _e in x if _filter_p(_e))  — replaces ilen(...) with no extra dependency
+    loop_var = "_e"
+    filter_key = f"_p{len(namespace)}"
+    namespace[filter_key] = try_compile_predicate(predicate.predicate)
+    length_key = f"_p{len(namespace)}"
+    namespace[length_key] = try_compile_predicate(predicate.length_p)
+    count_expr = ast.Call(
+        func=_name("sum"),
+        args=[
+            ast.GeneratorExp(
+                elt=_const(1),
+                generators=[
+                    ast.comprehension(
+                        target=ast.Name(id=loop_var, ctx=ast.Store()),
+                        iter=_x(),
+                        ifs=[ast.Call(func=_name(filter_key), args=[_name(loop_var)], keywords=[])],
+                        is_async=0,
+                    )
+                ],
+            )
+        ],
+        keywords=[],
+    )
+    return ast.Call(func=_name(length_key), args=[count_expr], keywords=[])
 
 
 @_to_ast.register

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -28,6 +28,7 @@ from predicate.not_in_predicate import NotInPredicate
 from predicate.predicate import AndPredicate, NotPredicate, OrPredicate, Predicate, XorPredicate
 from predicate.range_predicate import GeLePredicate, GeLtPredicate, GtLePredicate, GtLtPredicate
 from predicate.set_of_predicate import SetOfPredicate
+from predicate.tuple_of_predicate import TupleOfPredicate
 
 
 class NotCompilableError(Exception):
@@ -300,6 +301,35 @@ def _(predicate: ListOfPredicate, namespace: dict) -> ast.expr:
 @_to_ast.register
 def _(predicate: SetOfPredicate, namespace: dict) -> ast.expr:
     return _isinstance_and_all_ast(predicate, "set", namespace)
+
+
+@_to_ast.register
+def _(predicate: TupleOfPredicate, namespace: dict) -> ast.expr:
+    n = len(predicate.predicates)
+    len_check = ast.Compare(
+        left=ast.Call(func=ast.Name(id="len", ctx=ast.Load()), args=[_x()], keywords=[]),
+        ops=[ast.Eq()],
+        comparators=[_const(n)],
+    )
+    if n == 0:
+        return len_check
+
+    element_checks = []
+    for i, p in enumerate(predicate.predicates):
+        try:
+            inner_fn = compile_predicate(p).fn
+        except NotCompilableError:
+            inner_fn = p
+        key = f"_p{len(namespace)}"
+        namespace[key] = inner_fn
+        element_checks.append(
+            ast.Call(
+                func=ast.Name(id=key, ctx=ast.Load()),
+                args=[ast.Subscript(value=_x(), slice=_const(i), ctx=ast.Load())],
+                keywords=[],
+            )
+        )
+    return ast.BoolOp(op=ast.And(), values=[len_check, *element_checks])
 
 
 def compile_predicate[T](predicate: Predicate[T]) -> CompiledPredicate[T]:

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -10,11 +10,13 @@ from predicate.all_predicate import AllPredicate
 from predicate.always_false_predicate import AlwaysFalsePredicate
 from predicate.always_true_predicate import AlwaysTruePredicate
 from predicate.any_predicate import AnyPredicate
+from predicate.comp_predicate import CompPredicate
 from predicate.eq_predicate import EqPredicate
 from predicate.ge_predicate import GePredicate
 from predicate.gt_predicate import GtPredicate
 from predicate.has_key_predicate import HasKeyPredicate
 from predicate.in_predicate import InPredicate
+from predicate.is_close_predicate import IsClosePredicate
 from predicate.is_falsy_predicate import IsFalsyPredicate
 from predicate.is_instance_predicate import IsInstancePredicate
 from predicate.is_none_predicate import IsNonePredicate
@@ -23,6 +25,7 @@ from predicate.is_truthy_predicate import IsTruthyPredicate
 from predicate.le_predicate import LePredicate
 from predicate.list_of_predicate import ListOfPredicate
 from predicate.lt_predicate import LtPredicate
+from predicate.named_predicate import NamedPredicate
 from predicate.ne_predicate import NePredicate
 from predicate.not_in_predicate import NotInPredicate
 from predicate.predicate import AndPredicate, NotPredicate, OrPredicate, Predicate, XorPredicate
@@ -100,6 +103,11 @@ def _(predicate: AlwaysTruePredicate, namespace: dict) -> ast.expr:
 @_to_ast.register
 def _(predicate: AlwaysFalsePredicate, namespace: dict) -> ast.expr:
     return _const(False)
+
+
+@_to_ast.register
+def _(predicate: NamedPredicate, namespace: dict) -> ast.expr:
+    return _const(predicate.v)
 
 
 @_to_ast.register
@@ -301,6 +309,38 @@ def _(predicate: ListOfPredicate, namespace: dict) -> ast.expr:
 @_to_ast.register
 def _(predicate: SetOfPredicate, namespace: dict) -> ast.expr:
     return _isinstance_and_all_ast(predicate, "set", namespace)
+
+
+@_to_ast.register
+def _(predicate: IsClosePredicate, namespace: dict) -> ast.expr:
+    import math
+
+    namespace["_isclose"] = math.isclose
+    return ast.Call(
+        func=ast.Name(id="_isclose", ctx=ast.Load()),
+        args=[_x(), _const(predicate.target)],
+        keywords=[
+            ast.keyword(arg="rel_tol", value=_const(predicate.rel_tol)),
+            ast.keyword(arg="abs_tol", value=_const(predicate.abs_tol)),
+        ],
+    )
+
+
+@_to_ast.register
+def _(predicate: CompPredicate, namespace: dict) -> ast.expr:
+    try:
+        inner_fn = compile_predicate(predicate.predicate).fn
+    except NotCompilableError:
+        inner_fn = predicate.predicate
+    fn_key = f"_fn{len(namespace)}"
+    namespace[fn_key] = predicate.fn
+    p_key = f"_p{len(namespace)}"
+    namespace[p_key] = inner_fn
+    return ast.Call(
+        func=ast.Name(id=p_key, ctx=ast.Load()),
+        args=[ast.Call(func=ast.Name(id=fn_key, ctx=ast.Load()), args=[_x()], keywords=[])],
+        keywords=[],
+    )
 
 
 @_to_ast.register

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -72,8 +72,12 @@ class CompiledPredicate[T](Predicate[T]):
         return self.predicate.klass
 
 
+def _name(id: str) -> ast.Name:
+    return ast.Name(id=id, ctx=ast.Load())
+
+
 def _x() -> ast.Name:
-    return ast.Name(id="x", ctx=ast.Load())
+    return _name("x")
 
 
 def _const(v) -> ast.Constant:
@@ -87,7 +91,7 @@ def _cmp(ops: list, comparators: list) -> ast.Compare:
 def _delegate(predicate: Predicate, namespace: dict) -> ast.Call:
     key = f"_p{len(namespace)}"
     namespace[key] = predicate
-    return ast.Call(func=ast.Name(id=key, ctx=ast.Load()), args=[_x()], keywords=[])
+    return ast.Call(func=_name(key), args=[_x()], keywords=[])
 
 
 @singledispatch
@@ -152,14 +156,14 @@ def _(predicate: IsNotNonePredicate, namespace: dict) -> ast.expr:
 
 @_to_ast.register
 def _(predicate: IsTruthyPredicate, namespace: dict) -> ast.expr:
-    return ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[_x()], keywords=[])
+    return ast.Call(func=_name("bool"), args=[_x()], keywords=[])
 
 
 @_to_ast.register
 def _(predicate: IsFalsyPredicate, namespace: dict) -> ast.expr:
     return ast.UnaryOp(
         op=ast.Not(),
-        operand=ast.Call(func=ast.Name(id="bool", ctx=ast.Load()), args=[_x()], keywords=[]),
+        operand=ast.Call(func=_name("bool"), args=[_x()], keywords=[]),
     )
 
 
@@ -169,7 +173,7 @@ def _(predicate: InPredicate, namespace: dict) -> ast.expr:
         raise NotCompilableError(f"Cannot compile InPredicate with non-iterable value {predicate.v!r}")
     key = f"_s{len(namespace)}"
     namespace[key] = frozenset(predicate.v)
-    return _cmp([ast.In()], [ast.Name(id=key, ctx=ast.Load())])
+    return _cmp([ast.In()], [_name(key)])
 
 
 @_to_ast.register
@@ -178,7 +182,7 @@ def _(predicate: NotInPredicate, namespace: dict) -> ast.expr:
         raise NotCompilableError(f"Cannot compile NotInPredicate with non-iterable value {predicate.v!r}")
     key = f"_s{len(namespace)}"
     namespace[key] = frozenset(predicate.v)
-    return _cmp([ast.NotIn()], [ast.Name(id=key, ctx=ast.Load())])
+    return _cmp([ast.NotIn()], [_name(key)])
 
 
 @_to_ast.register
@@ -186,7 +190,7 @@ def _(predicate: HasKeyPredicate, namespace: dict) -> ast.expr:
     key = f"_k{len(namespace)}"
     namespace[key] = predicate.key
     return ast.Compare(
-        left=ast.Name(id=key, ctx=ast.Load()),
+        left=_name(key),
         ops=[ast.In()],
         comparators=[_x()],
     )
@@ -244,12 +248,8 @@ def _(predicate: NotPredicate, namespace: dict) -> ast.expr:
 @_to_ast.register
 def _(predicate: XorPredicate, namespace: dict) -> ast.expr:
     # bool(left_expr) ^ bool(right_expr)
-    bool_left = ast.Call(
-        func=ast.Name(id="bool", ctx=ast.Load()), args=[_to_ast(predicate.left, namespace)], keywords=[]
-    )
-    bool_right = ast.Call(
-        func=ast.Name(id="bool", ctx=ast.Load()), args=[_to_ast(predicate.right, namespace)], keywords=[]
-    )
+    bool_left = ast.Call(func=_name("bool"), args=[_to_ast(predicate.left, namespace)], keywords=[])
+    bool_right = ast.Call(func=_name("bool"), args=[_to_ast(predicate.right, namespace)], keywords=[])
     return ast.BinOp(left=bool_left, op=ast.BitXor(), right=bool_right)
 
 
@@ -270,8 +270,8 @@ def _any_all_ast(predicate: AllPredicate | AnyPredicate, fn_name: str, namespace
     loop_var = "_e"
     gen = ast.GeneratorExp(
         elt=ast.Call(
-            func=ast.Name(id=inner_key, ctx=ast.Load()),
-            args=[ast.Name(id=loop_var, ctx=ast.Load())],
+            func=_name(inner_key),
+            args=[_name(loop_var)],
             keywords=[],
         ),
         generators=[
@@ -283,7 +283,7 @@ def _any_all_ast(predicate: AllPredicate | AnyPredicate, fn_name: str, namespace
             )
         ],
     )
-    return ast.Call(func=ast.Name(id=fn_name, ctx=ast.Load()), args=[gen], keywords=[])
+    return ast.Call(func=_name(fn_name), args=[gen], keywords=[])
 
 
 @_to_ast.register
@@ -293,8 +293,8 @@ def _(predicate: AnyPredicate, namespace: dict) -> ast.expr:
 
 def _isinstance_and_all_ast(predicate: Predicate, type_name: str, namespace: dict) -> ast.expr:
     isinstance_check = ast.Call(
-        func=ast.Name(id="isinstance", ctx=ast.Load()),
-        args=[_x(), ast.Name(id=type_name, ctx=ast.Load())],
+        func=_name("isinstance"),
+        args=[_x(), _name(type_name)],
         keywords=[],
     )
     all_check = _any_all_ast(predicate, "all", namespace)
@@ -317,7 +317,7 @@ def _(predicate: IsClosePredicate, namespace: dict) -> ast.expr:
 
     namespace["_isclose"] = math.isclose
     return ast.Call(
-        func=ast.Name(id="_isclose", ctx=ast.Load()),
+        func=_name("_isclose"),
         args=[_x(), _const(predicate.target)],
         keywords=[
             ast.keyword(arg="rel_tol", value=_const(predicate.rel_tol)),
@@ -337,8 +337,8 @@ def _(predicate: CompPredicate, namespace: dict) -> ast.expr:
     p_key = f"_p{len(namespace)}"
     namespace[p_key] = inner_fn
     return ast.Call(
-        func=ast.Name(id=p_key, ctx=ast.Load()),
-        args=[ast.Call(func=ast.Name(id=fn_key, ctx=ast.Load()), args=[_x()], keywords=[])],
+        func=_name(p_key),
+        args=[ast.Call(func=_name(fn_key), args=[_x()], keywords=[])],
         keywords=[],
     )
 
@@ -347,7 +347,7 @@ def _(predicate: CompPredicate, namespace: dict) -> ast.expr:
 def _(predicate: TupleOfPredicate, namespace: dict) -> ast.expr:
     n = len(predicate.predicates)
     len_check = ast.Compare(
-        left=ast.Call(func=ast.Name(id="len", ctx=ast.Load()), args=[_x()], keywords=[]),
+        left=ast.Call(func=_name("len"), args=[_x()], keywords=[]),
         ops=[ast.Eq()],
         comparators=[_const(n)],
     )
@@ -358,7 +358,7 @@ def _(predicate: TupleOfPredicate, namespace: dict) -> ast.expr:
         key = f"_p{len(namespace)}"
         namespace[key] = try_compile_predicate(p)
         return ast.Call(
-            func=ast.Name(id=key, ctx=ast.Load()),
+            func=_name(key),
             args=[ast.Subscript(value=_x(), slice=_const(i), ctx=ast.Load())],
             keywords=[],
         )

--- a/predicate/formatter/format_dot.py
+++ b/predicate/formatter/format_dot.py
@@ -13,6 +13,7 @@ from predicate.always_false_predicate import AlwaysFalsePredicate
 from predicate.always_true_predicate import AlwaysTruePredicate
 from predicate.any_predicate import AnyPredicate
 from predicate.comp_predicate import CompPredicate
+from predicate.compile_predicate import CompiledPredicate
 from predicate.count_predicate import CountPredicate
 from predicate.dict_of_predicate import DictOfPredicate
 from predicate.eq_predicate import EqPredicate
@@ -123,6 +124,8 @@ def render(dot: Digraph, predicate: Predicate, node_nr: count):
         add_node_with_child = partial(_add_node_with_child, predicate=predicate)
 
         match predicate:
+            case CompiledPredicate(predicate=inner):
+                return to_value(inner)
             case AllPredicate(all_predicate):
                 return add_node_with_child("all", label="∀", child=all_predicate)
             case AlwaysFalsePredicate():

--- a/predicate/formatter/format_json.py
+++ b/predicate/formatter/format_json.py
@@ -6,6 +6,7 @@ from predicate.all_predicate import AllPredicate
 from predicate.always_false_predicate import AlwaysFalsePredicate
 from predicate.always_true_predicate import AlwaysTruePredicate
 from predicate.any_predicate import AnyPredicate
+from predicate.compile_predicate import CompiledPredicate
 from predicate.count_predicate import CountPredicate
 from predicate.dict_of_predicate import DictOfPredicate
 from predicate.eq_predicate import EqPredicate
@@ -72,6 +73,8 @@ def to_json(predicate: Predicate) -> dict[str, Any]:
 
     def to_value(predicate) -> tuple[str, Any]:
         match predicate:
+            case CompiledPredicate(predicate=inner):
+                return to_value(inner)
             case AllPredicate(all_predicate):
                 return "all", {"predicate": to_json(all_predicate)}
             case AlwaysFalsePredicate():

--- a/predicate/formatter/format_latex.py
+++ b/predicate/formatter/format_latex.py
@@ -4,6 +4,7 @@ from predicate.all_predicate import AllPredicate
 from predicate.always_false_predicate import AlwaysFalsePredicate
 from predicate.always_true_predicate import AlwaysTruePredicate
 from predicate.any_predicate import AnyPredicate
+from predicate.compile_predicate import CompiledPredicate
 from predicate.count_predicate import CountPredicate
 from predicate.eq_predicate import EqPredicate
 from predicate.ge_predicate import GePredicate
@@ -40,6 +41,8 @@ def set_to_latex_set(v: Iterable) -> str:
 def to_latex(predicate: Predicate, parameter: str = "x") -> str:
     """Format predicate as LaTeX."""
     match predicate:
+        case CompiledPredicate(predicate=inner):
+            return to_latex(inner, parameter=parameter)
         case AllPredicate(all_predicate):
             return f"\\forall {parameter} \\in S, {to_latex(all_predicate)}"
         case AlwaysFalsePredicate():

--- a/predicate/optimizer/list_of_optimizer.py
+++ b/predicate/optimizer/list_of_optimizer.py
@@ -1,0 +1,33 @@
+from predicate.always_false_predicate import AlwaysFalsePredicate
+from predicate.always_true_predicate import AlwaysTruePredicate
+from predicate.any_predicate import AnyPredicate
+from predicate.has_length_predicate import is_empty_p
+from predicate.is_instance_predicate import is_list_p
+from predicate.is_none_predicate import IsNonePredicate
+from predicate.is_not_none_predicate import IsNotNonePredicate
+from predicate.list_of_predicate import ListOfPredicate
+from predicate.optimizer.helpers import MaybeOptimized, NotOptimized, Optimized
+from predicate.predicate import NotPredicate
+
+
+def optimize_list_of_predicate[T](predicate: ListOfPredicate[T]) -> MaybeOptimized[T]:
+    from predicate.optimizer.predicate_optimizer import optimize
+
+    optimized = optimize(predicate.predicate)
+
+    match optimized:
+        case AlwaysTruePredicate():
+            # is_list_of_p(always_true_p) == is_list_p
+            return Optimized(is_list_p)
+        case AlwaysFalsePredicate():
+            # is_list_of_p(always_false_p) == is_list_p & is_empty_p  (vacuously true only for empty lists)
+            return Optimized(is_list_p & is_empty_p)
+        case NotPredicate(not_predicate):
+            # is_list_of_p(~p) == is_list_p & ~any_p(p)  (De Morgan)
+            return Optimized(is_list_p & NotPredicate(predicate=AnyPredicate(predicate=not_predicate)))
+        case IsNotNonePredicate():
+            return Optimized(is_list_p & NotPredicate(predicate=AnyPredicate(predicate=IsNonePredicate())))
+        case _:
+            pass
+
+    return NotOptimized() if optimized == predicate.predicate else Optimized(ListOfPredicate(predicate=optimized))

--- a/predicate/optimizer/predicate_optimizer.py
+++ b/predicate/optimizer/predicate_optimizer.py
@@ -1,6 +1,7 @@
 from predicate.all_predicate import AllPredicate
 from predicate.any_predicate import AnyPredicate
 from predicate.in_predicate import InPredicate
+from predicate.list_of_predicate import ListOfPredicate
 from predicate.not_in_predicate import NotInPredicate
 from predicate.optimizer.all_optimizer import optimize_all_predicate
 from predicate.optimizer.and_optimizer import optimize_and_predicate
@@ -8,6 +9,7 @@ from predicate.optimizer.any_optimizer import optimize_any_predicate
 from predicate.optimizer.helpers import MaybeOptimized, NotOptimized, Optimized
 from predicate.optimizer.in_optimizer import optimize_in_predicate
 from predicate.optimizer.intersects_optimizer import optimize_intersects_predicate
+from predicate.optimizer.list_of_optimizer import optimize_list_of_predicate
 from predicate.optimizer.not_in_optimizer import optimize_not_in_predicate
 from predicate.optimizer.not_optimizer import optimize_not_predicate
 from predicate.optimizer.or_optimizer import optimize_or_predicate
@@ -35,6 +37,8 @@ def optimizations[T](predicate: Predicate[T]) -> MaybeOptimized[T]:
             return optimize_in_predicate(in_predicate)
         case IntersectsPredicate() as intersects_predicate:
             return optimize_intersects_predicate(intersects_predicate)
+        case ListOfPredicate() as list_of_predicate:
+            return optimize_list_of_predicate(list_of_predicate)
         case NotInPredicate() as not_in_predicate:
             return optimize_not_in_predicate(not_in_predicate)
         case _:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ target-version = "py312"
 ban-relative-imports = "all"
 
 [tool.ruff.lint.per-file-ignores]
+# compile_predicate must be imported after exception_predicate to avoid a circular import
+# (is_none_predicate imports exception_p from the predicate package at module level)
+"predicate/__init__.py" = ["I001"]
 "test/*" = ["D101", "D400", "D415",  "S101"]
 "benchmarks/*" = ["D400", "D415", "S101"]
 

--- a/test/optimizer/test_list_of_predicate_optimizer.py
+++ b/test/optimizer/test_list_of_predicate_optimizer.py
@@ -1,0 +1,101 @@
+from predicate import (
+    always_false_p,
+    always_true_p,
+    any_p,
+    can_optimize,
+    eq_p,
+    is_list_of_p,
+    is_none_p,
+    is_not_none_p,
+    is_str_p,
+    ne_p,
+    optimize,
+)
+from predicate.has_length_predicate import is_empty_p
+from predicate.is_instance_predicate import is_list_p
+
+
+def test_optimize_list_of_true():
+    # is_list_of_p(always_true_p) == is_list_p
+    predicate = is_list_of_p(always_true_p)
+
+    assert can_optimize(predicate)
+
+    optimized = optimize(predicate)
+
+    assert optimized == is_list_p
+
+
+def test_optimize_list_of_false():
+    # is_list_of_p(always_false_p) == is_list_p & is_empty_p
+    predicate = is_list_of_p(always_false_p)
+
+    assert can_optimize(predicate)
+
+    optimized = optimize(predicate)
+
+    assert optimized == (is_list_p & is_empty_p)
+
+
+def test_optimize_list_of_not(p):
+    # is_list_of_p(~p) == is_list_p & ~any_p(p)
+    predicate = is_list_of_p(~p)
+
+    assert can_optimize(predicate)
+
+    optimized = optimize(predicate)
+
+    assert optimized == (is_list_p & ~any_p(p))
+
+
+def test_optimize_list_of_not_none():
+    # is_list_of_p(is_not_none_p) == is_list_p & ~any_p(is_none_p)
+    predicate = is_list_of_p(is_not_none_p)
+
+    assert can_optimize(predicate)
+
+    optimized = optimize(predicate)
+
+    assert optimized == (is_list_p & ~any_p(is_none_p))
+
+
+def test_optimize_list_of_inner():
+    # inner predicate is optimizable — propagate
+    predicate = is_list_of_p(~eq_p(2))
+
+    assert can_optimize(predicate)
+
+    optimized = optimize(predicate)
+
+    assert optimized == is_list_of_p(ne_p(2))
+
+
+def test_not_optimize_list_of():
+    predicate = is_list_of_p(is_str_p)
+
+    assert not can_optimize(predicate)
+
+
+def test_optimize_list_of_true_semantics():
+    optimized = optimize(is_list_of_p(always_true_p))
+
+    assert optimized([1, "x", None])
+    assert not optimized("not-a-list")
+    assert not optimized(42)
+
+
+def test_optimize_list_of_false_semantics():
+    optimized = optimize(is_list_of_p(always_false_p))
+
+    assert optimized([])
+    assert not optimized([1])
+    assert not optimized("not-a-list")
+
+
+def test_optimize_list_of_not_semantics(p):
+    optimized = optimize(is_list_of_p(~p))
+
+    original = is_list_of_p(~p)
+
+    for x in [[], [1, 2], ["a"], [True], [None]]:
+        assert optimized(x) == original(x)

--- a/test/spec/test_instrument_function.py
+++ b/test/spec/test_instrument_function.py
@@ -3,8 +3,9 @@ from typing import Any
 
 import pytest
 
-from predicate import Spec, ge_p, is_instrumented, is_int_p
+from predicate import ge_p, is_instrumented, is_int_p
 from predicate.spec.instrument import enrich_spec, instrument, instrument_function, instrument_module
+from predicate.spec.spec import Spec
 
 
 def test_instrument_ok():

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -20,6 +20,7 @@ from predicate import (
     is_bool_p,
     is_falsy_p,
     is_int_p,
+    is_list_of_p,
     is_none_p,
     is_not_none_p,
     is_str_p,
@@ -273,6 +274,22 @@ def test_compile_any_nested():
     cp = compile_predicate(any_p(gt_p(0) & lt_p(10)))
     assert cp([0, 5, 10])
     assert not cp([0, -1, 10])
+
+
+def test_compile_list_of():
+    cp = compile_predicate(is_list_of_p(gt_p(0)))
+    assert cp([1, 2, 3])
+    assert not cp([1, -1, 3])
+    assert cp([])
+    assert not cp("not-a-list")
+    assert not cp(42)
+
+
+def test_compile_list_of_nested():
+    cp = compile_predicate(is_list_of_p(gt_p(0) & lt_p(10)))
+    assert cp([1, 2, 9])
+    assert not cp([1, 10, 3])
+    assert not cp("not-a-list")
 
 
 def test_compile_fn_raises():

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -27,6 +27,7 @@ from predicate import (
     is_set_of_p,
     is_str_p,
     is_truthy_p,
+    is_tuple_of_p,
     le_p,
     lt_p,
     ne_p,
@@ -316,6 +317,28 @@ def test_compile_set_of_nested():
     assert cp({1, 2, 9})
     assert not cp({1, 10})
     assert not cp("not-a-set")
+
+
+def test_compile_tuple_of():
+    cp = compile_predicate(is_tuple_of_p(is_int_p, is_str_p))
+    assert cp((1, "hello"))
+    assert not cp((1, 2))
+    assert not cp(("hello", "world"))
+    assert not cp((1,))
+    assert not cp((1, "hello", True))
+
+
+def test_compile_tuple_of_empty():
+    cp = compile_predicate(is_tuple_of_p())
+    assert cp(())
+    assert not cp((1,))
+
+
+def test_compile_tuple_of_nested():
+    cp = compile_predicate(is_tuple_of_p(gt_p(0) & lt_p(10), gt_p(100)))
+    assert cp((5, 200))
+    assert not cp((0, 200))
+    assert not cp((5, 50))
 
 
 def test_compile_fn_raises():

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -16,6 +16,7 @@ from predicate import (
     gt_le_p,
     gt_lt_p,
     gt_p,
+    has_key_p,
     in_p,
     is_bool_p,
     is_falsy_p,
@@ -23,6 +24,7 @@ from predicate import (
     is_list_of_p,
     is_none_p,
     is_not_none_p,
+    is_set_of_p,
     is_str_p,
     is_truthy_p,
     le_p,
@@ -290,6 +292,30 @@ def test_compile_list_of_nested():
     assert cp([1, 2, 9])
     assert not cp([1, 10, 3])
     assert not cp("not-a-list")
+
+
+def test_compile_has_key():
+    cp = compile_predicate(has_key_p("a"))
+    assert cp({"a": 1})
+    assert cp({"a": 1, "b": 2})
+    assert not cp({"b": 1})
+    assert not cp({})
+
+
+def test_compile_set_of():
+    cp = compile_predicate(is_set_of_p(gt_p(0)))
+    assert cp({1, 2, 3})
+    assert cp(set())
+    assert not cp({1, -1, 3})
+    assert not cp([1, 2, 3])
+    assert not cp(42)
+
+
+def test_compile_set_of_nested():
+    cp = compile_predicate(is_set_of_p(gt_p(0) & lt_p(10)))
+    assert cp({1, 2, 9})
+    assert not cp({1, 10})
+    assert not cp("not-a-set")
 
 
 def test_compile_fn_raises():

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -249,9 +249,17 @@ def test_compile_optimize_then_compile():
 # --- NotCompilableError ---
 
 
-def test_compile_all_raises():
-    with pytest.raises(NotCompilableError):
-        compile_predicate(all_p(gt_p(0)))
+def test_compile_all():
+    cp = compile_predicate(all_p(gt_p(0)))
+    assert cp([1, 2, 3])
+    assert not cp([1, -1, 3])
+    assert cp([])
+
+
+def test_compile_all_nested():
+    cp = compile_predicate(all_p(gt_p(0) & lt_p(10)))
+    assert cp([1, 2, 9])
+    assert not cp([1, 10, 3])
 
 
 def test_compile_any_raises():
@@ -290,7 +298,7 @@ def test_try_compile_compilable():
 
 
 def test_try_compile_non_compilable_returns_original():
-    p = all_p(gt_p(0))
+    p = any_p(gt_p(0))
     result = try_compile_predicate(p)
     assert result is p
 

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -1,0 +1,331 @@
+"""Tests for compile_predicate."""
+
+import pytest
+
+from predicate import (
+    CompiledPredicate,
+    NotCompilableError,
+    all_p,
+    always_false_p,
+    always_true_p,
+    any_p,
+    compile_predicate,
+    eq_p,
+    fn_p,
+    ge_le_p,
+    ge_lt_p,
+    ge_p,
+    gt_le_p,
+    gt_lt_p,
+    gt_p,
+    in_p,
+    is_bool_p,
+    is_falsy_p,
+    is_int_p,
+    is_none_p,
+    is_not_none_p,
+    is_str_p,
+    is_truthy_p,
+    le_p,
+    lt_p,
+    ne_p,
+    not_in_p,
+    optimize,
+    regex_p,
+    try_compile_predicate,
+)
+
+# --- compile_predicate returns CompiledPredicate ---
+
+
+def test_compile_returns_compiled_predicate():
+    cp = compile_predicate(eq_p(1))
+    assert isinstance(cp, CompiledPredicate)
+
+
+# --- Leaf predicates ---
+
+
+def test_compile_eq():
+    cp = compile_predicate(eq_p(42))
+    assert cp(42)
+    assert not cp(0)
+
+
+def test_compile_ne():
+    cp = compile_predicate(ne_p(42))
+    assert cp(0)
+    assert not cp(42)
+
+
+def test_compile_gt():
+    cp = compile_predicate(gt_p(0))
+    assert cp(1)
+    assert not cp(0)
+    assert not cp(-1)
+
+
+def test_compile_ge():
+    cp = compile_predicate(ge_p(0))
+    assert cp(0)
+    assert cp(1)
+    assert not cp(-1)
+
+
+def test_compile_lt():
+    cp = compile_predicate(lt_p(10))
+    assert cp(9)
+    assert not cp(10)
+
+
+def test_compile_le():
+    cp = compile_predicate(le_p(10))
+    assert cp(10)
+    assert cp(9)
+    assert not cp(11)
+
+
+def test_compile_is_none():
+    cp = compile_predicate(is_none_p)
+    assert cp(None)
+    assert not cp(0)
+    assert not cp(False)
+
+
+def test_compile_is_not_none():
+    cp = compile_predicate(is_not_none_p)
+    assert cp(0)
+    assert cp(False)
+    assert not cp(None)
+
+
+def test_compile_is_truthy():
+    cp = compile_predicate(is_truthy_p)
+    assert cp(1)
+    assert cp("x")
+    assert not cp(0)
+    assert not cp("")
+
+
+def test_compile_is_falsy():
+    cp = compile_predicate(is_falsy_p)
+    assert cp(0)
+    assert cp("")
+    assert not cp(1)
+    assert not cp("x")
+
+
+def test_compile_in():
+    cp = compile_predicate(in_p({1, 2, 3}))
+    assert cp(1)
+    assert cp(3)
+    assert not cp(4)
+
+
+def test_compile_not_in():
+    cp = compile_predicate(not_in_p({1, 2, 3}))
+    assert cp(4)
+    assert not cp(1)
+
+
+# --- Range predicates ---
+
+
+def test_compile_ge_le():
+    cp = compile_predicate(ge_le_p(0, 10))
+    assert cp(0)
+    assert cp(5)
+    assert cp(10)
+    assert not cp(-1)
+    assert not cp(11)
+
+
+def test_compile_ge_lt():
+    cp = compile_predicate(ge_lt_p(0, 10))
+    assert cp(0)
+    assert cp(9)
+    assert not cp(10)
+
+
+def test_compile_gt_le():
+    cp = compile_predicate(gt_le_p(0, 10))
+    assert cp(1)
+    assert cp(10)
+    assert not cp(0)
+
+
+def test_compile_gt_lt():
+    cp = compile_predicate(gt_lt_p(0, 10))
+    assert cp(1)
+    assert cp(9)
+    assert not cp(0)
+    assert not cp(10)
+
+
+# --- IsInstancePredicate (delegation) ---
+
+
+def test_compile_is_instance_int():
+    cp = compile_predicate(is_int_p)
+    assert cp(1)
+    assert not cp("x")
+
+
+def test_compile_is_instance_preserves_bool_int_semantics():
+    """is_int_p should return False for bool values (non-standard but intentional)."""
+    cp = compile_predicate(is_int_p)
+    assert not cp(True)
+    assert not cp(False)
+
+
+def test_compile_is_instance_str():
+    cp = compile_predicate(is_str_p)
+    assert cp("hello")
+    assert not cp(1)
+
+
+def test_compile_is_bool():
+    cp = compile_predicate(is_bool_p)
+    assert cp(True)
+    assert not cp(1)
+
+
+# --- Boolean combinators ---
+
+
+def test_compile_and():
+    cp = compile_predicate(gt_p(0) & lt_p(10))
+    assert cp(5)
+    assert not cp(0)
+    assert not cp(10)
+
+
+def test_compile_or():
+    cp = compile_predicate(eq_p(1) | eq_p(2))
+    assert cp(1)
+    assert cp(2)
+    assert not cp(3)
+
+
+def test_compile_not():
+    cp = compile_predicate(~gt_p(0))
+    assert cp(0)
+    assert cp(-1)
+    assert not cp(1)
+
+
+def test_compile_xor():
+    cp = compile_predicate(eq_p(1) ^ eq_p(2))
+    assert cp(1)
+    assert cp(2)
+    assert not cp(3)
+
+
+def test_compile_xor_both_true_is_false():
+    # Both sides true at once: this predicate is always false for a single int value
+    # but we can construct a logical case: eq_p(1) ^ eq_p(1)
+    cp = compile_predicate(eq_p(1) ^ eq_p(1))
+    assert not cp(1)
+    assert not cp(0)
+
+
+# --- Nested / combined ---
+
+
+def test_compile_nested_and_or():
+    cp = compile_predicate((gt_p(0) & le_p(5)) | (gt_p(10) & le_p(15)))
+    assert cp(3)
+    assert cp(12)
+    assert not cp(0)
+    assert not cp(7)
+
+
+def test_compile_optimize_then_compile():
+    p = optimize(ge_p(0) & le_p(10))
+    cp = compile_predicate(p)
+    assert cp(5)
+    assert not cp(11)
+
+
+# --- NotCompilableError ---
+
+
+def test_compile_all_raises():
+    with pytest.raises(NotCompilableError):
+        compile_predicate(all_p(gt_p(0)))
+
+
+def test_compile_any_raises():
+    with pytest.raises(NotCompilableError):
+        compile_predicate(any_p(gt_p(0)))
+
+
+def test_compile_fn_raises():
+    with pytest.raises(NotCompilableError):
+        compile_predicate(fn_p(lambda x: x > 0))
+
+
+def test_compile_regex_raises():
+    with pytest.raises(NotCompilableError):
+        compile_predicate(regex_p(r"\d+"))
+
+
+def test_compile_always_true_raises():
+    with pytest.raises(NotCompilableError):
+        compile_predicate(always_true_p)
+
+
+def test_compile_always_false_raises():
+    with pytest.raises(NotCompilableError):
+        compile_predicate(always_false_p)
+
+
+# --- try_compile_predicate ---
+
+
+def test_try_compile_compilable():
+    p = gt_p(0) & lt_p(10)
+    cp = try_compile_predicate(p)
+    assert isinstance(cp, CompiledPredicate)
+    assert cp(5)
+
+
+def test_try_compile_non_compilable_returns_original():
+    p = all_p(gt_p(0))
+    result = try_compile_predicate(p)
+    assert result is p
+
+
+# --- Delegation of introspection to wrapped predicate ---
+
+
+def test_compiled_repr_delegates():
+    p = gt_p(0) & lt_p(10)
+    cp = compile_predicate(p)
+    assert repr(cp) == repr(p)
+
+
+def test_compiled_count_delegates():
+    p = gt_p(0) & lt_p(10)
+    cp = compile_predicate(p)
+    assert cp.count == p.count
+
+
+def test_compiled_contains_delegates():
+    inner = gt_p(0)
+    p = inner & lt_p(10)
+    cp = compile_predicate(p)
+    assert inner in cp
+
+
+def test_compiled_explain_failure_delegates():
+    p = gt_p(0)
+    cp = compile_predicate(p)
+    assert cp.explain_failure(-1) == p.explain_failure(-1)
+
+
+def test_compiled_eq_based_on_wrapped_predicate():
+    p = gt_p(0)
+    cp1 = compile_predicate(p)
+    cp2 = compile_predicate(p)
+    assert cp1 == cp2

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -262,9 +262,17 @@ def test_compile_all_nested():
     assert not cp([1, 10, 3])
 
 
-def test_compile_any_raises():
-    with pytest.raises(NotCompilableError):
-        compile_predicate(any_p(gt_p(0)))
+def test_compile_any():
+    cp = compile_predicate(any_p(gt_p(0)))
+    assert cp([0, 0, 1])
+    assert not cp([0, -1, 0])
+    assert not cp([])
+
+
+def test_compile_any_nested():
+    cp = compile_predicate(any_p(gt_p(0) & lt_p(10)))
+    assert cp([0, 5, 10])
+    assert not cp([0, -1, 10])
 
 
 def test_compile_fn_raises():
@@ -298,7 +306,7 @@ def test_try_compile_compilable():
 
 
 def test_try_compile_non_compilable_returns_original():
-    p = any_p(gt_p(0))
+    p = fn_p(lambda x: x > 0)
     result = try_compile_predicate(p)
     assert result is p
 

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -3,8 +3,6 @@
 import pytest
 
 from predicate import (
-    CompiledPredicate,
-    NotCompilableError,
     all_p,
     always_false_p,
     always_true_p,
@@ -34,6 +32,7 @@ from predicate import (
     regex_p,
     try_compile_predicate,
 )
+from predicate.compile_predicate import CompiledPredicate, NotCompilableError
 
 # --- compile_predicate returns CompiledPredicate ---
 

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -7,6 +7,7 @@ from predicate import (
     always_false_p,
     always_true_p,
     any_p,
+    comp_p,
     compile_predicate,
     eq_p,
     fn_p,
@@ -19,6 +20,7 @@ from predicate import (
     has_key_p,
     in_p,
     is_bool_p,
+    is_close_p,
     is_falsy_p,
     is_int_p,
     is_list_of_p,
@@ -37,6 +39,7 @@ from predicate import (
     try_compile_predicate,
 )
 from predicate.compile_predicate import CompiledPredicate, NotCompilableError
+from predicate.named_predicate import NamedPredicate
 
 # --- compile_predicate returns CompiledPredicate ---
 
@@ -339,6 +342,45 @@ def test_compile_tuple_of_nested():
     assert cp((5, 200))
     assert not cp((0, 200))
     assert not cp((5, 50))
+
+
+def test_compile_named_true():
+    cp = compile_predicate(NamedPredicate(name="p", v=True))
+    assert cp(0)
+    assert cp(None)
+    assert cp("anything")
+
+
+def test_compile_named_false():
+    cp = compile_predicate(NamedPredicate(name="p", v=False))
+    assert not cp(0)
+    assert not cp(None)
+
+
+def test_compile_is_close():
+    cp = compile_predicate(is_close_p(1.0))
+    assert cp(1.0)
+    assert cp(1.0 + 1e-10)
+    assert not cp(1.1)
+
+
+def test_compile_is_close_abs_tol():
+    cp = compile_predicate(is_close_p(0.0, abs_tol=0.01))
+    assert cp(0.005)
+    assert not cp(0.02)
+
+
+def test_compile_comp():
+    cp = compile_predicate(comp_p(abs, gt_p(0)))
+    assert cp(-1)
+    assert cp(1)
+    assert not cp(0)
+
+
+def test_compile_comp_with_lambda():
+    cp = compile_predicate(comp_p(lambda x: x * 2, eq_p(10)))
+    assert cp(5)
+    assert not cp(4)
 
 
 def test_compile_fn_raises():

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -302,14 +302,18 @@ def test_compile_regex_raises():
         compile_predicate(regex_p(r"\d+"))
 
 
-def test_compile_always_true_raises():
-    with pytest.raises(NotCompilableError):
-        compile_predicate(always_true_p)
+def test_compile_always_true():
+    cp = compile_predicate(always_true_p)
+    assert cp(0)
+    assert cp(None)
+    assert cp("anything")
 
 
-def test_compile_always_false_raises():
-    with pytest.raises(NotCompilableError):
-        compile_predicate(always_false_p)
+def test_compile_always_false():
+    cp = compile_predicate(always_false_p)
+    assert not cp(0)
+    assert not cp(None)
+    assert not cp("anything")
 
 
 # --- try_compile_predicate ---

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -19,13 +19,16 @@ from predicate import (
     gt_lt_p,
     gt_p,
     has_key_p,
+    has_length_p,
     in_p,
     is_bool_p,
     is_close_p,
+    is_empty_p,
     is_falsy_p,
     is_int_p,
     is_list_of_p,
     is_none_p,
+    is_not_empty_p,
     is_not_none_p,
     is_set_of_p,
     is_str_p,
@@ -305,6 +308,28 @@ def test_compile_has_key():
     assert cp({"a": 1, "b": 2})
     assert not cp({"b": 1})
     assert not cp({})
+
+
+def test_compile_has_length():
+    cp = compile_predicate(has_length_p(eq_p(3)))
+    assert cp([1, 2, 3])
+    assert cp("abc")
+    assert not cp([1, 2])
+    assert not cp([])
+
+
+def test_compile_is_empty():
+    cp = compile_predicate(is_empty_p)
+    assert cp([])
+    assert cp("")
+    assert not cp([1])
+
+
+def test_compile_is_not_empty():
+    cp = compile_predicate(is_not_empty_p)
+    assert cp([1])
+    assert cp("x")
+    assert not cp([])
 
 
 def test_compile_set_of():

--- a/test/test_compile_predicate.py
+++ b/test/test_compile_predicate.py
@@ -9,6 +9,7 @@ from predicate import (
     any_p,
     comp_p,
     compile_predicate,
+    count_p,
     eq_p,
     fn_p,
     ge_le_p,
@@ -381,6 +382,31 @@ def test_compile_comp_with_lambda():
     cp = compile_predicate(comp_p(lambda x: x * 2, eq_p(10)))
     assert cp(5)
     assert not cp(4)
+
+
+def test_compile_count():
+    cp = compile_predicate(count_p(gt_p(0), eq_p(2)))
+    assert cp([1, 2, -1])  # exactly 2 positives
+    assert not cp([1, 2, 3])  # 3 positives
+    assert not cp([1, -1, -1])  # 1 positive
+
+
+def test_compile_count_zero():
+    cp = compile_predicate(count_p(gt_p(0), eq_p(0)))
+    assert cp([-1, -2])
+    assert not cp([1, -1])
+
+
+def test_compile_count_empty():
+    cp = compile_predicate(count_p(gt_p(0), eq_p(0)))
+    assert cp([])
+
+
+def test_compile_count_with_range_length():
+    cp = compile_predicate(count_p(gt_p(0), ge_p(2)))
+    assert cp([1, 2, 3])
+    assert cp([1, 2, -1])
+    assert not cp([1, -1, -1])
 
 
 def test_compile_fn_raises():

--- a/test/test_exception_predicate.py
+++ b/test/test_exception_predicate.py
@@ -1,6 +1,7 @@
 import pytest
 
-from predicate import PredicateError, exception_p
+from predicate import exception_p
+from predicate.exception_predicate import PredicateError
 
 
 def test_exception_p():

--- a/test/test_is_odd_predicate.py
+++ b/test/test_is_odd_predicate.py
@@ -1,4 +1,5 @@
-from predicate import Spec, exercise, is_int_p, is_odd_p
+from predicate import exercise, is_int_p, is_odd_p
+from predicate.spec.spec import Spec
 
 
 def test_is_odd():

--- a/test/test_none_predicate.py
+++ b/test/test_none_predicate.py
@@ -1,7 +1,8 @@
 import pytest
 from helpers import exercise_predicate
 
-from predicate import PredicateError, is_int_p, is_none_p, none_is_exception_p, none_is_false_p, none_is_true_p
+from predicate import is_int_p, is_none_p, none_is_exception_p, none_is_false_p, none_is_true_p
+from predicate.exception_predicate import PredicateError
 from predicate.explain import explain
 
 

--- a/test/test_performance.py
+++ b/test/test_performance.py
@@ -1,17 +1,53 @@
-# from predicate import is_int_p, all_p
-#
-#
-# def test_predicate(benchmark):
-#     predicate = all_p(is_int_p)
-#
-#     result = benchmark(predicate, [1, 2, 3])
-#
-#     assert result
-#
-# def test_old(benchmark):
-#     def foo():
-#         return all(isinstance(x, int) for x in [1, 2 ,3])
-#
-#     result = benchmark(foo)
-#
-#     assert result
+"""Performance comparison: interpreted vs compiled predicates."""
+
+from predicate import compile_predicate, eq_p, ge_le_p, ge_p, gt_p, in_p, le_p, lt_p, ne_p, optimize
+
+
+def test_eval_eq_interpreted(benchmark):
+    p = eq_p(42)
+    benchmark(p, 42)
+
+
+def test_eval_eq_compiled(benchmark):
+    cp = compile_predicate(eq_p(42))
+    benchmark(cp, 42)
+
+
+def test_eval_and_interpreted(benchmark):
+    p = gt_p(0) & lt_p(100) & ne_p(50)
+    benchmark(p, 25)
+
+
+def test_eval_and_compiled(benchmark):
+    cp = compile_predicate(gt_p(0) & lt_p(100) & ne_p(50))
+    benchmark(cp, 25)
+
+
+def test_eval_range_interpreted(benchmark):
+    p = ge_le_p(0, 100)
+    benchmark(p, 50)
+
+
+def test_eval_range_compiled(benchmark):
+    cp = compile_predicate(ge_le_p(0, 100))
+    benchmark(cp, 50)
+
+
+def test_eval_optimize_then_interpreted(benchmark):
+    p = optimize(ge_p(0) & le_p(100))
+    benchmark(p, 50)
+
+
+def test_eval_optimize_then_compiled(benchmark):
+    cp = compile_predicate(optimize(ge_p(0) & le_p(100)))
+    benchmark(cp, 50)
+
+
+def test_eval_in_interpreted(benchmark):
+    p = in_p({1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+    benchmark(p, 5)
+
+
+def test_eval_in_compiled(benchmark):
+    cp = compile_predicate(in_p({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+    benchmark(cp, 5)

--- a/test/test_performance.py
+++ b/test/test_performance.py
@@ -1,6 +1,6 @@
 """Performance comparison: interpreted vs compiled predicates vs raw Python."""
 
-from predicate import compile_predicate, eq_p, ge_le_p, ge_p, gt_p, in_p, le_p, lt_p, ne_p, optimize
+from predicate import all_p, compile_predicate, eq_p, ge_le_p, ge_p, gt_p, in_p, le_p, lt_p, ne_p, optimize
 
 _S = frozenset(range(1, 11))
 
@@ -76,3 +76,23 @@ def test_eval_range_raw(benchmark):
 def test_eval_in_raw(benchmark):
     f = lambda x: x in _S  # noqa: E731
     benchmark(f, 5)
+
+
+# --- all_p ---
+
+_DATA = list(range(1, 101))
+
+
+def test_eval_all_interpreted(benchmark):
+    p = all_p(gt_p(0))
+    benchmark(p, _DATA)
+
+
+def test_eval_all_compiled(benchmark):
+    cp = compile_predicate(all_p(gt_p(0)))
+    benchmark(cp, _DATA)
+
+
+def test_eval_all_raw(benchmark):
+    f = lambda x: all(e > 0 for e in x)  # noqa: E731
+    benchmark(f, _DATA)

--- a/test/test_performance.py
+++ b/test/test_performance.py
@@ -1,6 +1,8 @@
-"""Performance comparison: interpreted vs compiled predicates."""
+"""Performance comparison: interpreted vs compiled predicates vs raw Python."""
 
 from predicate import compile_predicate, eq_p, ge_le_p, ge_p, gt_p, in_p, le_p, lt_p, ne_p, optimize
+
+_S = frozenset(range(1, 11))
 
 
 def test_eval_eq_interpreted(benchmark):
@@ -51,3 +53,26 @@ def test_eval_in_interpreted(benchmark):
 def test_eval_in_compiled(benchmark):
     cp = compile_predicate(in_p({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
     benchmark(cp, 5)
+
+
+# --- Raw Python lambdas for baseline ---
+
+
+def test_eval_eq_raw(benchmark):
+    f = lambda x: x == 42  # noqa: E731
+    benchmark(f, 42)
+
+
+def test_eval_and_raw(benchmark):
+    f = lambda x: x > 0 and x < 100 and x != 50  # noqa: E731
+    benchmark(f, 25)
+
+
+def test_eval_range_raw(benchmark):
+    f = lambda x: 0 <= x <= 100  # noqa: E731
+    benchmark(f, 50)
+
+
+def test_eval_in_raw(benchmark):
+    f = lambda x: x in _S  # noqa: E731
+    benchmark(f, 5)

--- a/test/test_performance.py
+++ b/test/test_performance.py
@@ -1,6 +1,6 @@
 """Performance comparison: interpreted vs compiled predicates vs raw Python."""
 
-from predicate import all_p, compile_predicate, eq_p, ge_le_p, ge_p, gt_p, in_p, le_p, lt_p, ne_p, optimize
+from predicate import all_p, any_p, compile_predicate, eq_p, ge_le_p, ge_p, gt_p, in_p, le_p, lt_p, ne_p, optimize
 
 _S = frozenset(range(1, 11))
 
@@ -95,4 +95,22 @@ def test_eval_all_compiled(benchmark):
 
 def test_eval_all_raw(benchmark):
     f = lambda x: all(e > 0 for e in x)  # noqa: E731
+    benchmark(f, _DATA)
+
+
+# --- any_p ---
+
+
+def test_eval_any_interpreted(benchmark):
+    p = any_p(gt_p(0))
+    benchmark(p, _DATA)
+
+
+def test_eval_any_compiled(benchmark):
+    cp = compile_predicate(any_p(gt_p(0)))
+    benchmark(cp, _DATA)
+
+
+def test_eval_any_raw(benchmark):
+    f = lambda x: any(e > 0 for e in x)  # noqa: E731
     benchmark(f, _DATA)

--- a/test/test_performance.py
+++ b/test/test_performance.py
@@ -1,6 +1,20 @@
 """Performance comparison: interpreted vs compiled predicates vs raw Python."""
 
-from predicate import all_p, any_p, compile_predicate, eq_p, ge_le_p, ge_p, gt_p, in_p, le_p, lt_p, ne_p, optimize
+from predicate import (
+    all_p,
+    any_p,
+    compile_predicate,
+    eq_p,
+    ge_le_p,
+    ge_p,
+    gt_p,
+    in_p,
+    is_list_of_p,
+    le_p,
+    lt_p,
+    ne_p,
+    optimize,
+)
 
 _S = frozenset(range(1, 11))
 
@@ -113,4 +127,22 @@ def test_eval_any_compiled(benchmark):
 
 def test_eval_any_raw(benchmark):
     f = lambda x: any(e > 0 for e in x)  # noqa: E731
+    benchmark(f, _DATA)
+
+
+# --- is_list_of_p ---
+
+
+def test_eval_list_of_interpreted(benchmark):
+    p = is_list_of_p(gt_p(0))
+    benchmark(p, _DATA)
+
+
+def test_eval_list_of_compiled(benchmark):
+    cp = compile_predicate(is_list_of_p(gt_p(0)))
+    benchmark(cp, _DATA)
+
+
+def test_eval_list_of_raw(benchmark):
+    f = lambda x: isinstance(x, list) and all(e > 0 for e in x)  # noqa: E731
     benchmark(f, _DATA)


### PR DESCRIPTION
Introduces compile_predicate(), try_compile_predicate(), NotCompilableError, and CompiledPredicate. Walks the predicate tree and builds a Python AST, then calls compile() to produce a single native lambda — eliminating the chain of __call__ dispatches for supported predicate types.

Supported types: all leaf comparisons (eq, ne, gt, ge, lt, le, in, not_in, is_none, is_not_none, is_truthy, is_falsy), all range predicates (ge_le, ge_lt, gt_le, gt_lt), IsInstancePredicate (via delegation), and all boolean combinators (and, or, not, xor) recursively.

CompiledPredicate delegates repr, count, explain_failure, and __contains__ to the wrapped predicate, so introspection is fully preserved.
