### PR TITLE
Generalize predicates to broader abstract types

### DIFF
--- a/predicate/dict_of_predicate.py
+++ b/predicate/dict_of_predicate.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
@@ -19,7 +19,7 @@ class DictOfPredicate(Predicate):
         self.key_value_predicates = [(to_key_p(key_p), value_p) for key_p, value_p in key_value_predicates]
 
     def __call__(self, x: Any) -> bool:
-        if not isinstance(x, dict):
+        if not isinstance(x, Mapping):
             return False
 
         if not x:
@@ -43,8 +43,8 @@ class DictOfPredicate(Predicate):
 
     @override
     def explain_failure(self, x: Any, *args, **kwargs) -> dict:
-        if not isinstance(x, dict):
-            return {"reason": f"{x} is not an instance of a dict"}
+        if not isinstance(x, Mapping):
+            return {"reason": f"{x} is not an instance of a Mapping"}
         if not x:
             return {"reason": "empty dict"}
         if failing := first(

--- a/predicate/has_key_predicate.py
+++ b/predicate/has_key_predicate.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import override
 
@@ -10,14 +11,14 @@ class HasKeyPredicate[T](Predicate[T]):
 
     key: T
 
-    def __call__(self, v: dict) -> bool:
+    def __call__(self, v: Mapping) -> bool:
         return self.key in v.keys()
 
     def __repr__(self) -> str:
         return f'has_key_p("{self.key}")'
 
     @override
-    def explain_failure(self, v: dict) -> dict:
+    def explain_failure(self, v: Mapping) -> dict:
         return {"reason": f"Key '{self.key}' is missing in {v}"}
 
 

--- a/predicate/has_path_predicate.py
+++ b/predicate/has_path_predicate.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, override
 
@@ -12,33 +13,29 @@ class HasPathPredicate[T](Predicate[T]):
     path: list[Predicate]
 
     def __call__(self, x: Any) -> bool:
-        match x:
-            case dict(d):
-                return match_dict(d, path=self.path)
-            case _:
-                return False
+        if isinstance(x, Mapping):
+            return match_dict(x, path=self.path)
+        return False
 
     def __repr__(self) -> str:
         return f"has_path_p({predicates_repr(self.path)})"
 
     @override
     def explain_failure(self, x: Any) -> dict:
-        match x:
-            case dict():
-                current = x
-                for i, p in enumerate(self.path):
-                    if not isinstance(current, dict):
-                        return {"reason": f"Expected a dict at path position {i}, got {type(current).__name__}"}
-                    keys = [k for k in current if p(k)]
-                    if not keys:
-                        return {"reason": f"No key matching {p!r} found at path position {i}"}
-                    current = current[keys[0]]
-                return {"reason": f"Dictionary {x} didn't match path"}  # pragma: no cover
-            case _:
-                return {"reason": f"Value {x} is not a dict"}
+        if not isinstance(x, Mapping):
+            return {"reason": f"Value {x} is not a Mapping"}
+        current = x
+        for i, p in enumerate(self.path):
+            if not isinstance(current, Mapping):
+                return {"reason": f"Expected a Mapping at path position {i}, got {type(current).__name__}"}
+            keys = [k for k in current if p(k)]
+            if not keys:
+                return {"reason": f"No key matching {p!r} found at path position {i}"}
+            current = current[keys[0]]
+        return {"reason": f"Mapping {x} didn't match path"}  # pragma: no cover
 
 
-def match_dict(x: dict, *, path: list[Predicate]) -> bool:
+def match_dict(x: Mapping, *, path: list[Predicate]) -> bool:
     first_p, *rest = path
     found = (v for k, v in x.items() if first_p(k))
     return any(match_rest(value, rest) for value in found)
@@ -46,8 +43,8 @@ def match_dict(x: dict, *, path: list[Predicate]) -> bool:
 
 def match_rest(value: Any, rest_path: list[Predicate]) -> bool:
     match (value, rest_path):
-        case (dict(d), [_, *_]):
-            return match_dict(d, path=rest_path)
+        case (_, [_, *_]) if isinstance(value, Mapping):
+            return match_dict(value, path=rest_path)
         case (list(l), [first_p, *rest]):
             return first_p(l) and any(match_rest(v, rest) for v in l)
         case (_, [p]):

--- a/predicate/implies.py
+++ b/predicate/implies.py
@@ -166,7 +166,7 @@ def _(predicate: IsSupersetPredicate, other: Predicate) -> bool:
 def _(predicate: IntersectsPredicate, other: Predicate) -> bool:
     match other:
         case IntersectsPredicate(v):
-            return predicate.v.issubset(v)
+            return predicate.v <= v
         case _:
             return False
 

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -1,6 +1,8 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
+from fractions import Fraction
 from functools import partial
 from ipaddress import IPv4Address, IPv6Address
 from typing import Any, Callable, Iterable, Iterator, override
@@ -288,7 +290,7 @@ class XorPredicate[T](Predicate[T]):
         }
 
 
-type ConstrainedT[T: (int, str, float, datetime, UUID, IPv4Address, IPv6Address)] = T
+type ConstrainedT[T: (int, str, float, datetime, date, Decimal, Fraction, UUID, IPv4Address, IPv6Address)] = T
 
 
 def predicate_partial[T](

--- a/predicate/set_predicates.py
+++ b/predicate/set_predicates.py
@@ -1,3 +1,4 @@
+from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 
 from predicate.predicate import Predicate
@@ -7,9 +8,9 @@ from predicate.predicate import Predicate
 class IsSubsetPredicate[T](Predicate[T]):
     """A predicate class that models the 'subset' predicate."""
 
-    v: set[T]
+    v: AbstractSet[T]
 
-    def __call__(self, v: set[T]) -> bool:
+    def __call__(self, v: AbstractSet[T]) -> bool:
         return v <= self.v
 
     def __repr__(self) -> str:
@@ -20,9 +21,9 @@ class IsSubsetPredicate[T](Predicate[T]):
 class IsRealSubsetPredicate[T](Predicate[T]):
     """A predicate class that models the 'real subset' predicate."""
 
-    v: set[T]
+    v: AbstractSet[T]
 
-    def __call__(self, v: set[T]) -> bool:
+    def __call__(self, v: AbstractSet[T]) -> bool:
         return v < self.v
 
     def __repr__(self) -> str:
@@ -33,9 +34,9 @@ class IsRealSubsetPredicate[T](Predicate[T]):
 class IsSupersetPredicate[T](Predicate[T]):
     """A predicate class that models the 'superset' predicate."""
 
-    v: set[T]
+    v: AbstractSet[T]
 
-    def __call__(self, v: set[T]) -> bool:
+    def __call__(self, v: AbstractSet[T]) -> bool:
         return v >= self.v
 
     def __repr__(self) -> str:
@@ -46,9 +47,9 @@ class IsSupersetPredicate[T](Predicate[T]):
 class IsRealSupersetPredicate[T](Predicate[T]):
     """A predicate class that models the 'real superset' predicate."""
 
-    v: set[T]
+    v: AbstractSet[T]
 
-    def __call__(self, v: set[T]) -> bool:
+    def __call__(self, v: AbstractSet[T]) -> bool:
         return v > self.v
 
     def __repr__(self) -> str:
@@ -59,35 +60,35 @@ class IsRealSupersetPredicate[T](Predicate[T]):
 class IntersectsPredicate[T](Predicate[T]):
     """A predicate class that returns True if the value shares at least one element with a given set."""
 
-    v: set[T]
+    v: AbstractSet[T]
 
-    def __call__(self, v) -> bool:
+    def __call__(self, v: AbstractSet[T]) -> bool:
         return not self.v.isdisjoint(v)
 
     def __repr__(self) -> str:
         return f"intersects_p({self.v})"
 
 
-def intersects_p[T](v: set[T]) -> IntersectsPredicate[T]:
+def intersects_p[T](v: AbstractSet[T]) -> IntersectsPredicate[T]:
     """Return True if the value shares at least one element with v, otherwise False."""
     return IntersectsPredicate(v)
 
 
-def is_subset_p[T](v: set[T]) -> IsSubsetPredicate[T]:
+def is_subset_p[T](v: AbstractSet[T]) -> IsSubsetPredicate[T]:
     """Return True if the value is a subset, otherwise False."""
     return IsSubsetPredicate(v)
 
 
-def is_real_subset_p[T](v: set[T]) -> IsRealSubsetPredicate[T]:
+def is_real_subset_p[T](v: AbstractSet[T]) -> IsRealSubsetPredicate[T]:
     """Return True if the value is a real subset, otherwise False."""
     return IsRealSubsetPredicate(v)
 
 
-def is_superset_p[T](v: set[T]) -> IsSupersetPredicate[T]:
+def is_superset_p[T](v: AbstractSet[T]) -> IsSupersetPredicate[T]:
     """Return True if the value is a superset, otherwise False."""
     return IsSupersetPredicate(v)
 
 
-def is_real_superset_p[T](v: set[T]) -> IsRealSupersetPredicate[T]:
+def is_real_superset_p[T](v: AbstractSet[T]) -> IsRealSupersetPredicate[T]:
     """Return True if the value is a real superset, otherwise False."""
     return IsRealSupersetPredicate(v)

--- a/predicate/struct_predicate.py
+++ b/predicate/struct_predicate.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, override
 
@@ -15,25 +16,24 @@ class StructPredicate[T](Predicate[T]):
     optional: dict[str, Predicate]
 
     def __call__(self, x: Any) -> bool:
-        match x:
-            case dict(d):
-                if set(d) - set(self.required) - set(self.optional):
+        if not isinstance(x, Mapping):
+            return False
+
+        if set(x) - set(self.required) - set(self.optional):
+            return False
+
+        for key, predicate in self.required.items():
+            if key not in x:
+                return False
+            if not predicate(x[key]):
+                return False
+
+        for key, predicate in self.optional.items():
+            if value := x.get(key, None):
+                if not predicate(value):
                     return False
 
-                for key, predicate in self.required.items():
-                    if key not in d:
-                        return False
-                    if not predicate(d[key]):
-                        return False
-
-                for key, predicate in self.optional.items():
-                    if value := d.get(key, None):
-                        if not predicate(value):
-                            return False
-
-                return True
-            case _:
-                return False
+        return True
 
     def __repr__(self) -> str:
         return (
@@ -42,25 +42,24 @@ class StructPredicate[T](Predicate[T]):
 
     @override
     def explain_failure(self, x: Any, *args, **kwargs) -> dict:
-        match x:
-            case dict(d):
-                if additional := first(set(d) - set(self.required) - set(self.optional), None):
-                    return {"reason": f"Field `{additional}` is unknown"}
+        if not isinstance(x, Mapping):
+            return {"reason": f"{x} is not an instance of a Mapping"}
 
-                for key, predicate in self.required.items():
-                    if key not in d:
-                        return {"reason": f"Required field `{key}` missing"}
-                    value = d[key]
-                    if not predicate(value):
-                        return {
-                            "key": key,
-                            "value": value,
-                            "reason": f"Value '{value}' for key '{key}' doesn't satisfy predicate {predicate!r}",
-                        }
+        if additional := first(set(x) - set(self.required) - set(self.optional), None):
+            return {"reason": f"Field `{additional}` is unknown"}
 
-                return {"reason": "Unknown"}
-            case _:
-                return {"reason": f"{x} is not an instance of a dict"}
+        for key, predicate in self.required.items():
+            if key not in x:
+                return {"reason": f"Required field `{key}` missing"}
+            value = x[key]
+            if not predicate(value):
+                return {
+                    "key": key,
+                    "value": value,
+                    "reason": f"Value '{value}' for key '{key}' doesn't satisfy predicate {predicate!r}",
+                }
+
+        return {"reason": "Unknown"}
 
 
 def is_struct_p(

--- a/test/test_dict_of_predicate.py
+++ b/test/test_dict_of_predicate.py
@@ -88,7 +88,7 @@ def test_is_dict_of_explain_empty():
 def test_is_dict_of_explain_not_a_dict():
     predicate = is_dict_of_p(("x", is_int_p), (eq_p("y"), is_str_p))
 
-    expected = {"reason": "3 is not an instance of a dict", "result": False}
+    expected = {"reason": "3 is not an instance of a Mapping", "result": False}
     assert explain(predicate, 3) == expected
 
 

--- a/test/test_has_path_predicate.py
+++ b/test/test_has_path_predicate.py
@@ -68,7 +68,7 @@ def test_has_path_predicate_no_dict():
 def test_has_path_predicate_no_dict_explain():
     predicate = has_path_p()
 
-    expected = {"reason": "Value foo is not a dict", "result": False}
+    expected = {"reason": "Value foo is not a Mapping", "result": False}
     assert explain(predicate, "foo") == expected
 
 
@@ -104,5 +104,5 @@ def test_has_path_predicate_non_dict_intermediate_explain():
     has_y = eq_p("y")
     predicate = has_path_p(has_x, has_y)
 
-    expected = {"reason": "Expected a dict at path position 1, got int", "result": False}
+    expected = {"reason": "Expected a Mapping at path position 1, got int", "result": False}
     assert explain(predicate, {"x": 13}) == expected

--- a/test/test_struct_predicate.py
+++ b/test/test_struct_predicate.py
@@ -59,7 +59,7 @@ def test_is_struct_with_optional(value, is_person_with_optional_email_p):
 def test_is_struct_p_explain_not_a_dict(is_person_p):
     expected = {
         "result": False,
-        "reason": "42 is not an instance of a dict",
+        "reason": "42 is not an instance of a Mapping",
     }
     assert explain(is_person_p, 42) == expected
 


### PR DESCRIPTION
- Set predicates (is_subset_p, is_superset_p, intersects_p, etc.) now accept AbstractSet[T] instead of set[T], enabling use with frozenset and other Set-like types
- HasKeyPredicate, DictOfPredicate, StructPredicate, HasPathPredicate now accept Mapping instead of dict
- ConstrainedT extended with date, Decimal, and Fraction
- Fix implies.py to use <= instead of .issubset() for AbstractSet
