### PR TITLE
Fix three inconsistencies in predicate.py

### DIFF
--- a/predicate/all_predicate.py
+++ b/predicate/all_predicate.py
@@ -23,7 +23,8 @@ class AllPredicate[T](Predicate[T]):
         return f"all_p({self.predicate!r})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.predicate.klass
 
     @override

--- a/predicate/always_false_predicate.py
+++ b/predicate/always_false_predicate.py
@@ -23,7 +23,8 @@ class AlwaysFalsePredicate(Predicate):
         yield 0
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(Any)
 
 

--- a/predicate/always_true_predicate.py
+++ b/predicate/always_true_predicate.py
@@ -19,7 +19,8 @@ class AlwaysTruePredicate(Predicate):
         yield 1
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(Any)
 
 

--- a/predicate/any_predicate.py
+++ b/predicate/any_predicate.py
@@ -23,7 +23,8 @@ class AnyPredicate[T](Predicate[T]):
         return f"any_p({self.predicate!r})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.predicate.klass
 
     @override

--- a/predicate/compile_predicate.py
+++ b/predicate/compile_predicate.py
@@ -70,7 +70,8 @@ class CompiledPredicate[T](Predicate[T]):
         return self.predicate.explain_failure(x)
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.predicate.klass
 
 

--- a/predicate/eq_predicate.py
+++ b/predicate/eq_predicate.py
@@ -17,7 +17,8 @@ class EqPredicate[T](Predicate[T]):
         return f"eq_p({self.v!r})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(self.v)
 
     @override

--- a/predicate/ge_predicate.py
+++ b/predicate/ge_predicate.py
@@ -17,7 +17,8 @@ class GePredicate[T](Predicate[T]):
         return f"ge_p({self.v!r})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(self.v)
 
     @override

--- a/predicate/gt_predicate.py
+++ b/predicate/gt_predicate.py
@@ -17,7 +17,8 @@ class GtPredicate[T](Predicate[T]):
         return f"gt_p({self.v!r})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(self.v)
 
     @override

--- a/predicate/in_predicate.py
+++ b/predicate/in_predicate.py
@@ -44,7 +44,8 @@ class InPredicate[T](Predicate[T]):
         return {"reason": f"{x} is not in {self!r}"}
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         if isinstance(self.v, Iterable):
             return class_from_set(self.v)
         return Any

--- a/predicate/is_close_predicate.py
+++ b/predicate/is_close_predicate.py
@@ -17,7 +17,8 @@ class IsClosePredicate[T](Predicate[T]):
         return math.isclose(x, self.target, rel_tol=self.rel_tol, abs_tol=self.abs_tol)
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return float
 
     def __repr__(self) -> str:

--- a/predicate/is_instance_predicate.py
+++ b/predicate/is_instance_predicate.py
@@ -28,7 +28,8 @@ class IsInstancePredicate[T](Predicate[T]):
         return f"is_{name}_p"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.instance_klass  # type: ignore
 
     @override

--- a/predicate/is_predicate.py
+++ b/predicate/is_predicate.py
@@ -17,7 +17,8 @@ class IsPredicate[T](Predicate[T]):
         return f"is_p({self.v!r})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(self.v)
 
     @override

--- a/predicate/is_subclass_predicate.py
+++ b/predicate/is_subclass_predicate.py
@@ -28,7 +28,8 @@ class IsSubclassPredicate[T](Predicate[T]):
                 return f"is_{klass.__name__.lower()}_p"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.class_or_tuple  # type: ignore
 
     @override

--- a/predicate/le_predicate.py
+++ b/predicate/le_predicate.py
@@ -17,7 +17,8 @@ class LePredicate[T](Predicate[T]):
         return f"le_p({self.v!r})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(self.v)
 
     @override

--- a/predicate/list_of_predicate.py
+++ b/predicate/list_of_predicate.py
@@ -29,7 +29,8 @@ class ListOfPredicate[T](Predicate[T]):
         return f"is_list_of_p({self.predicate})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return Predicate[self.predicate.klass]  # type: ignore[name-defined]
 
     @override

--- a/predicate/lt_predicate.py
+++ b/predicate/lt_predicate.py
@@ -17,7 +17,8 @@ class LtPredicate[T](Predicate[T]):
         return f"lt_p({self.v!r})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(self.v)
 
     @override

--- a/predicate/ne_predicate.py
+++ b/predicate/ne_predicate.py
@@ -17,7 +17,8 @@ class NePredicate[T](Predicate[T]):
         return f"ne_p({self.v!r})"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(self.v)
 
     @override

--- a/predicate/not_in_predicate.py
+++ b/predicate/not_in_predicate.py
@@ -24,7 +24,8 @@ class NotInPredicate[T](Predicate[T]):
         return f"not_in_p({self.v.__class__.__name__}())"
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         if isinstance(self.v, Iterable):
             return class_from_set(self.v)
         return Any

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -29,7 +29,7 @@ class Predicate[T]:
 
     def __xor__(self, predicate: "Predicate") -> "Predicate":
         """Return the 'xor' predicate."""
-        return XorPredicate(left=self, right=predicate)
+        return XorPredicate(left=resolve_predicate(self), right=resolve_predicate(predicate))
 
     def __invert__(self) -> "Predicate":
         """Return the 'negated' predicate."""
@@ -83,8 +83,6 @@ def resolve_predicate[T](predicate: Predicate[T]) -> Predicate[T]:
 @dataclass
 class AndPredicate[T](Predicate[T]):
     """A predicate class that models the 'and' predicate.
-
-    ```
 
     Attributes
     ----------
@@ -153,8 +151,6 @@ class AndPredicate[T](Predicate[T]):
 class NotPredicate[T](Predicate[T]):
     """A predicate class that models the 'not' predicate.
 
-    ```
-
     Attributes
     ----------
     predicate: Predicate[T]
@@ -192,8 +188,6 @@ class NotPredicate[T](Predicate[T]):
 class OrPredicate[T](Predicate[T]):
     """A predicate class that models the 'or' predicate.
 
-    ```
-
     Attributes
     ----------
     left: Predicate[T]
@@ -217,7 +211,7 @@ class OrPredicate[T](Predicate[T]):
                 return False
 
     def __repr__(self) -> str:
-        return f"{repr(self.left)} | {repr(self.right)}"
+        return f"{self.left!r} | {self.right!r}"
 
     def __contains__(self, predicate: Predicate[T]) -> bool:
         return predicate == self or predicate in self.left or predicate in self.right
@@ -242,8 +236,6 @@ class OrPredicate[T](Predicate[T]):
 @dataclass
 class XorPredicate[T](Predicate[T]):
     """A predicate class that models the 'xor' predicate.
-
-    ```
 
     Attributes
     ----------

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -45,7 +45,6 @@ class Predicate[T]:
         return 0
 
     @property
-    @abstractmethod
     def klass(self) -> type:
         raise NotImplementedError
 

--- a/predicate/predicate.py
+++ b/predicate/predicate.py
@@ -45,11 +45,8 @@ class Predicate[T]:
         return 0
 
     @property
+    @abstractmethod
     def klass(self) -> type:
-        return self.get_klass()
-
-    # @abstractmethod
-    def get_klass(self) -> type:
         raise NotImplementedError
 
     def explain(self, x: Any, *args, **kwargs) -> dict:
@@ -113,7 +110,8 @@ class AndPredicate[T](Predicate[T]):
         return predicate == self or predicate in self.left or predicate in self.right
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.left.klass
 
     @override
@@ -171,7 +169,8 @@ class NotPredicate[T](Predicate[T]):
         return predicate == self or predicate in self.predicate
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.predicate.klass
 
     @override
@@ -217,7 +216,8 @@ class OrPredicate[T](Predicate[T]):
         return predicate == self or predicate in self.left or predicate in self.right
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.left.klass
 
     @override
@@ -266,7 +266,8 @@ class XorPredicate[T](Predicate[T]):
         return predicate == self or predicate in self.left or predicate in self.right
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.left.klass
 
     @override

--- a/predicate/range_predicate.py
+++ b/predicate/range_predicate.py
@@ -16,7 +16,8 @@ class RangePredicate[T](Predicate[T]):
     upper: ConstrainedT
 
     @override
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return type(self.lower)
 
 

--- a/predicate/set_of_predicate.py
+++ b/predicate/set_of_predicate.py
@@ -24,7 +24,8 @@ class SetOfPredicate[T](Predicate[T]):
     def __repr__(self) -> str:
         return f"is_set_of_p({self.predicate})"
 
-    def get_klass(self) -> type:
+    @property
+    def klass(self) -> type:
         return self.predicate.klass
 
     @override


### PR DESCRIPTION
- __xor__: call resolve_predicate() like __and__ and __or__ already do
- OrPredicate.__repr__: use !r format spec consistently with And/XorPredicate
- Remove stray backtick fences from And/Or/Xor/NotPredicate docstrings