### PR TITLE
Improve generate_count, generate_is_subclass, and generate_not_in gen…

### DIFF
--- a/predicate/generator/generate_false.py
+++ b/predicate/generator/generate_false.py
@@ -19,6 +19,7 @@ from predicate.count_predicate import CountPredicate
 from predicate.dict_of_predicate import DictOfPredicate
 from predicate.eq_predicate import EqPredicate
 from predicate.exactly_predicate import ExactlyPredicate
+from predicate.exception_predicate import ExceptionPredicate
 from predicate.fn_predicate import FnPredicate
 from predicate.ge_predicate import GePredicate
 from predicate.generator.helpers import (
@@ -128,6 +129,11 @@ def generate_and(predicate: AndPredicate) -> Iterator:
 
 @generate_false.register
 def generate_always_true(_predicate: AlwaysTruePredicate) -> Iterator:
+    yield from []
+
+
+@generate_false.register
+def generate_exception(_predicate: ExceptionPredicate) -> Iterator:
     yield from []
 
 

--- a/predicate/generator/generate_false.py
+++ b/predicate/generator/generate_false.py
@@ -1,11 +1,12 @@
 import random
 import sys
+import warnings
 from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta
 from functools import singledispatch
 from itertools import chain, cycle, repeat
 from types import UnionType
-from typing import Final, get_args
+from typing import Final, Hashable, get_args
 from uuid import UUID
 
 from more_itertools import first, flatten, interleave, random_permutation, take
@@ -23,7 +24,6 @@ from predicate.ge_predicate import GePredicate
 from predicate.generator.helpers import (
     default_size_p,
     generate_anys,
-    generate_ints,
     generate_strings,
     generate_uuids,
     random_anys,
@@ -313,14 +313,9 @@ def generate_fn_p(predicate: FnPredicate) -> Iterator:
 
 @generate_false.register
 def generate_in(predicate: InPredicate) -> Iterator:
-    # TODO: combine with generate_not_in true
-    if isinstance(predicate.v, Iterable):
-        for item in predicate.v:
-            match item:
-                case int():
-                    yield from generate_ints(~predicate)
-                case str():
-                    yield from generate_strings(~predicate)
+    from predicate import generate_true
+
+    yield from generate_true(NotInPredicate(v=predicate.v))
 
 
 @generate_false.register
@@ -393,8 +388,6 @@ def generate_truthy(_predicate: IsTruthyPredicate) -> Iterator:
 
 @generate_false.register
 def generate_is_instance_p(predicate: IsInstancePredicate) -> Iterator:
-    from typing import Hashable
-
     if predicate.instance_klass[0] is Hashable:
         yield from random_non_hashables()
         return
@@ -593,16 +586,26 @@ def generate_exactly_n(exactly_predicate: ExactlyPredicate, *, predicates: list[
 
 @generate_false.register
 def generate_count(count_predicate: CountPredicate) -> Iterator:
+    from predicate import generate_true
+
     predicate = count_predicate.predicate
     length_p = count_predicate.length_p
 
-    # TODO: this is a minimal set. Also create iterables that contains some false items (which are not counted)
-    yield from generate_all_p(AllPredicate(predicate=predicate), length_p=length_p)
+    invalid_counts = (c for c in generate_false(length_p) if c >= 0)
+
+    while True:
+        count = next(invalid_counts)
+        true_values = list(take(count, generate_true(predicate)))
+
+        yield list(random_permutation(true_values))
+
+        nr_false = random.randint(1, 5)
+        false_values = list(take(nr_false, generate_false(predicate)))
+        if false_values:
+            yield list(random_permutation(true_values + false_values))
 
 
 def _subclasses(klass: type) -> set:
-    import warnings
-
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         return set(klass.__subclasses__())
@@ -614,20 +617,16 @@ def generate_is_subclass(is_subclass_predicate: IsSubclassPredicate) -> Iterator
 
     match is_subclass_predicate.class_or_tuple:
         case tuple(klasses):
-            subclasses = set(flatten(_subclasses(klass) for klass in klasses))
-            if non_subclasses := all_sub_classes - subclasses:
-                while True:
-                    yield from non_subclasses
+            target_klasses = list(klasses)
         case UnionType() as union_type:
-            subclasses = set(flatten(_subclasses(klass) for klass in get_args(union_type)))
-            if non_subclasses := all_sub_classes - subclasses:
-                while True:
-                    yield from non_subclasses
+            target_klasses = list(get_args(union_type))
         case _ as klass:
-            subclasses = _subclasses(klass)
-            if non_subclasses := all_sub_classes - subclasses:
-                while True:
-                    yield from non_subclasses
+            target_klasses = [klass]
+
+    subclasses = set(flatten(_subclasses(klass) for klass in target_klasses))
+    if non_subclasses := all_sub_classes - subclasses:
+        while True:
+            yield from non_subclasses
 
 
 @generate_false.register

--- a/predicate/generator/generate_true.py
+++ b/predicate/generator/generate_true.py
@@ -33,6 +33,8 @@ from predicate.ge_predicate import GePredicate, ge_p
 from predicate.generator.helpers import (
     default_length_p,
     generate_anys,
+    generate_datetimes,
+    generate_floats,
     generate_ints,
     generate_lambda,
     generate_strings,
@@ -449,6 +451,10 @@ def generate_not(predicate: NotPredicate) -> Iterator:
 
 def _generator_for_item(item, predicate: NotInPredicate) -> Iterator:
     match item:
+        case datetime():
+            return generate_datetimes(predicate)
+        case float():
+            return generate_floats(predicate)
         case int():
             return generate_ints(predicate)
         case str():

--- a/predicate/generator/generate_true.py
+++ b/predicate/generator/generate_true.py
@@ -27,12 +27,14 @@ from predicate.count_predicate import CountPredicate
 from predicate.dict_of_predicate import DictOfPredicate, is_dict_of_p
 from predicate.eq_predicate import EqPredicate, eq_p
 from predicate.exactly_predicate import ExactlyPredicate
+from predicate.exception_predicate import ExceptionPredicate
 from predicate.fn_predicate import FnPredicate
 from predicate.ge_predicate import GePredicate, ge_p
 from predicate.generator.helpers import (
     default_length_p,
     generate_anys,
     generate_ints,
+    generate_lambda,
     generate_strings,
     generate_uuids,
     random_anys,
@@ -64,6 +66,7 @@ from predicate.has_length_predicate import HasLengthPredicate
 from predicate.has_path_predicate import HasPathPredicate
 from predicate.in_predicate import InPredicate
 from predicate.is_async_predicate import IsAsyncPredicate
+from predicate.is_callable_predicate import IsCallablePredicate
 from predicate.is_close_predicate import IsClosePredicate
 from predicate.is_falsy_predicate import IsFalsyPredicate
 from predicate.is_instance_predicate import IsInstancePredicate
@@ -173,6 +176,11 @@ def generate_any_p(any_predicate: AnyPredicate, *, length_p: Predicate = default
 @generate_true.register
 def generate_always_true(_predicate: AlwaysTruePredicate, **_kwargs) -> Iterator:
     yield from random_anys()
+
+
+@generate_true.register
+def generate_exception(_predicate: ExceptionPredicate) -> Iterator:
+    yield from []
 
 
 @generate_true.register
@@ -526,6 +534,16 @@ def generate_is_instance_p(predicate: IsInstancePredicate, **kwargs) -> Iterator
         yield from random_predicates(**kwargs)
     else:
         raise ValueError(f"No generator found for {klass}")
+
+
+@generate_true.register
+def generate_is_callable_p(predicate: IsCallablePredicate) -> Iterator:
+    arg_names = [f"arg{i}" for i in range(len(predicate.params))]
+    fn = generate_lambda(arg_names)
+    fn.__annotations__ = dict(zip(arg_names, predicate.params, strict=False))
+    fn.__annotations__["return"] = predicate.return_type
+    while True:
+        yield fn
 
 
 @generate_true.register

--- a/predicate/generator/generate_true.py
+++ b/predicate/generator/generate_true.py
@@ -439,20 +439,24 @@ def generate_not(predicate: NotPredicate) -> Iterator:
     yield from generate_false(predicate.predicate)
 
 
+def _generator_for_item(item, predicate: NotInPredicate) -> Iterator:
+    match item:
+        case int():
+            return generate_ints(predicate)
+        case str():
+            return generate_strings(predicate)
+        case UUID():
+            return generate_uuids(predicate)
+        case _:
+            raise ValueError(f"Can't generate for type {type(item)}")
+
+
 @generate_true.register
 def generate_not_in(predicate: NotInPredicate) -> Iterator:
-    # TODO: not correct yet
     if isinstance(predicate.v, Iterable):
-        for item in predicate.v:
-            match item:
-                case int():
-                    yield from generate_ints(predicate)
-                case str():
-                    yield from generate_strings(predicate)
-                case UUID():
-                    yield from generate_uuids(predicate)
-                case _:
-                    raise ValueError(f"Can't generate for type {type(item)}")
+        generators = {type(item): _generator_for_item(item, predicate) for item in predicate.v}
+        if generators:
+            yield from random_first_from_iterables(*generators.values())
 
 
 @generate_true.register
@@ -706,25 +710,36 @@ def generate_count(count_predicate: CountPredicate) -> Iterator:
     predicate = count_predicate.predicate
     length_p = count_predicate.length_p
 
-    # TODO: this is a minimal set. Also create iterables that contains some false items (which are not counted)
-    yield from generate_all_p(AllPredicate(predicate=predicate), length_p=length_p)
+    valid_counts = generate_true(length_p)
+
+    while True:
+        count = next(valid_counts)
+        true_values = list(take(count, generate_true(predicate)))
+
+        yield list(random_permutation(true_values))
+
+        nr_false = random.randint(1, 5)
+        false_values = list(take(nr_false, generate_false(predicate)))
+        if false_values:
+            yield list(random_permutation(true_values + false_values))
+
+
+def _yield_subclasses(klasses: list[type]) -> Iterator:
+    while True:
+        for klass in klasses:
+            yield klass
+            yield from klass.__subclasses__()
 
 
 @generate_true.register
 def generate_is_subclass(is_subclass_predicate: IsSubclassPredicate) -> Iterator:
     match is_subclass_predicate.class_or_tuple:
         case tuple(klasses):
-            while True:
-                for klass in klasses:
-                    yield from klass.__subclasses__()
+            yield from _yield_subclasses(list(klasses))
         case UnionType() as union_type:
-            while True:
-                for klass in get_args(union_type):
-                    yield from klass.__subclasses__()
+            yield from _yield_subclasses(list(get_args(union_type)))
         case _ as klass:
-            subclasses = klass.__subclasses__()
-            while True:
-                yield from subclasses
+            yield from _yield_subclasses([klass])
 
 
 @generate_true.register

--- a/predicate/generator/helpers.py
+++ b/predicate/generator/helpers.py
@@ -343,6 +343,14 @@ def sample_optional_fields(optional: dict[str, Any], generators: dict[str, Itera
     return {key: next(generators[key]) for key in optional_keys}
 
 
+def generate_datetimes(predicate: Predicate[datetime]) -> Iterator[datetime]:
+    yield from (item for item in random_datetimes() if predicate(item))
+
+
+def generate_floats(predicate: Predicate[float]) -> Iterator[float]:
+    yield from (item for item in random_floats() if predicate(item))
+
+
 def generate_strings(predicate: Predicate[str]) -> Iterator[str]:
     yield from (item for item in random_strings() if predicate(item))
 

--- a/test/generator/generate_false/test_generate_count.py
+++ b/test/generator/generate_false/test_generate_count.py
@@ -1,8 +1,26 @@
+from more_itertools import take
+
 from generator.generate_false.helpers import assert_generated_false
-from predicate import count_p, eq_p, ge_p
+from predicate import count_p, eq_p, ge_p, generate_false
 
 
 def test_generate_count():
     predicate = count_p(predicate=ge_p(1), length_p=eq_p(1))
+
+    assert_generated_false(predicate)
+
+
+def test_generate_count_includes_non_matching_items():
+    """Generated false iterables may include items that don't match the predicate."""
+    predicate = count_p(predicate=ge_p(1), length_p=eq_p(2))
+
+    values = take(20, generate_false(predicate))
+
+    for value in values:
+        assert not predicate(value)
+
+
+def test_generate_count_zero_count():
+    predicate = count_p(predicate=ge_p(1), length_p=eq_p(3))
 
     assert_generated_false(predicate)

--- a/test/generator/generate_false/test_generate_exception.py
+++ b/test/generator/generate_false/test_generate_exception.py
@@ -1,0 +1,10 @@
+from more_itertools import take
+
+from predicate import generate_false
+from predicate.exception_predicate import exception_p
+
+
+def test_generate_exception():
+    values = take(5, generate_false(exception_p))
+
+    assert not values

--- a/test/generator/generate_true/test_generate_count.py
+++ b/test/generator/generate_true/test_generate_count.py
@@ -1,8 +1,27 @@
+from more_itertools import take
+
 from generator.generate_true.helpers import assert_generated_true
-from predicate import count_p, eq_p, ge_p
+from predicate import count_p, eq_p, ge_p, generate_true
 
 
 def test_generate_count():
     predicate = count_p(predicate=ge_p(1), length_p=eq_p(1))
+
+    assert_generated_true(predicate)
+
+
+def test_generate_count_includes_non_matching_items():
+    """Generated iterables should include items that don't match the predicate."""
+    predicate = count_p(predicate=ge_p(1), length_p=eq_p(2))
+
+    values = take(20, generate_true(predicate))
+
+    assert any(len(v) > 2 for v in values), "Expected some iterables with extra non-matching items"
+    for value in values:
+        assert predicate(value)
+
+
+def test_generate_count_zero():
+    predicate = count_p(predicate=ge_p(1), length_p=eq_p(0))
 
     assert_generated_true(predicate)

--- a/test/generator/generate_true/test_generate_exception.py
+++ b/test/generator/generate_true/test_generate_exception.py
@@ -1,0 +1,10 @@
+from more_itertools import take
+
+from predicate import generate_true
+from predicate.exception_predicate import exception_p
+
+
+def test_generate_exception():
+    values = take(5, generate_true(exception_p))
+
+    assert not values

--- a/test/generator/generate_true/test_generate_is_callable.py
+++ b/test/generator/generate_true/test_generate_is_callable.py
@@ -1,0 +1,14 @@
+from generator.generate_true.helpers import assert_generated_true
+from predicate.is_callable_predicate import is_callable_p
+
+
+def test_generate_is_callable_no_params():
+    predicate = is_callable_p([], bool)
+
+    assert_generated_true(predicate)
+
+
+def test_generate_is_callable_with_params():
+    predicate = is_callable_p([int, str], bool)
+
+    assert_generated_true(predicate)

--- a/test/generator/generate_true/test_generate_not_in.py
+++ b/test/generator/generate_true/test_generate_not_in.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+
+import pytest
+from more_itertools import take
+
+from generator.generate_true.helpers import assert_generated_true
+from predicate import generate_true
+from predicate.not_in_predicate import not_in_p
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        not_in_p([2, 3, 4]),
+        not_in_p(["foo", "bar"]),
+        not_in_p([1.0, 2.5, 3.14]),
+        not_in_p([datetime(2024, 1, 1), datetime(2024, 6, 15)]),
+        not_in_p([uuid.uuid4(), uuid.uuid4()]),
+    ],
+)
+def test_generate_not_in(predicate):
+    assert_generated_true(predicate)
+
+
+def test_generate_not_in_unknown():
+    predicate = not_in_p({None})
+    with pytest.raises(ValueError):
+        take(5, generate_true(predicate))

--- a/test/generator/generate_true/test_generate_true.py
+++ b/test/generator/generate_true/test_generate_true.py
@@ -140,17 +140,6 @@ def test_generate_true_or(predicate_pair):
     assert_generated_true(predicate)
 
 
-@pytest.mark.parametrize(
-    "predicate",
-    [
-        not_in_p(["foo", "bar"]),
-        not_in_p([uuid.uuid4(), uuid.uuid4()]),
-    ],
-)
-def test_generate_true_not_in_type(predicate):
-    assert_generated_true(predicate)
-
-
 def test_generate_tee():
     predicate = tee_p(fn=lambda x: x) & eq_p(2)
 
@@ -454,12 +443,6 @@ def test_generate_true_unknown_compare(compare_predicate):
 )
 def test_generate_true_unknown_range(range_predicate):
     predicate = range_predicate(lower="bar", upper="foo")
-    with pytest.raises(ValueError):
-        take(5, generate_true(predicate))
-
-
-def test_generate_true_not_in_p_unknown():
-    predicate = not_in_p({None})
     with pytest.raises(ValueError):
         take(5, generate_true(predicate))
 


### PR DESCRIPTION
…erators

- generate_true/false count: yield iterables with mixed true/false items; false generator now uses generate_false(length_p) for correct bad counts
- generate_true is_subclass: include class itself; unify arms via _yield_subclasses
- generate_false is_subclass: unify arms; move warnings import to top level; move Hashable import to top level
- generate_true not_in: fix infinite-loop bug by collecting one generator per unique type via dict comprehension + _generator_for_item helper
- generate_false in: delegate to generate_true(NotInPredicate) to eliminate duplication

🤖 Created with help from [Claude Code](https://claude.com/claude-code)